### PR TITLE
feat: implement Accordion component

### DIFF
--- a/components/Accordion/Accordion.module.css
+++ b/components/Accordion/Accordion.module.css
@@ -1,12 +1,107 @@
+/* Root */
 .root {
-  background-color: var(--ds-color-surface-default);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Variants */
+.variant-default {
   border: 1px solid var(--ds-color-border-default);
   border-radius: var(--ds-borderRadius-card);
-  padding: var(--ds-spacing-component-md);
-  color: var(--ds-color-text-default);
+  overflow: hidden;
+  background-color: var(--ds-color-surface-default);
+}
+
+.variant-default .item + .item {
+  border-top: 1px solid var(--ds-color-border-default);
 }
 
 .variant-outlined {
-  background-color: transparent;
-  border-color: var(--ds-color-border-strong);
+  gap: var(--ds-spacing-component-sm);
+}
+
+.variant-outlined .item {
+  border: 1px solid var(--ds-color-border-default);
+  border-radius: var(--ds-borderRadius-card);
+  overflow: hidden;
+  background-color: var(--ds-color-surface-default);
+}
+
+.variant-flush .item + .item {
+  border-top: 1px solid var(--ds-color-border-subtle);
+}
+
+/* Item */
+.itemDisabled {
+  opacity: 0.45;
+}
+
+/* Trigger */
+.trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--ds-spacing-component-md);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--ds-color-text-default);
+  font-family: var(--ds-typography-fontFamily-body);
+  font-size: var(--ds-typography-fontSize-md);
+  font-weight: var(--ds-typography-fontWeight-medium);
+  line-height: var(--ds-typography-lineHeight-normal);
+  transition: background-color var(--ds-transition-fast);
+}
+
+.trigger:hover:not(:disabled) {
+  background-color: var(--ds-color-background-subtle);
+}
+
+.trigger:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--ds-color-border-focus);
+}
+
+.trigger:disabled {
+  cursor: not-allowed;
+}
+
+.triggerLabel {
+  flex: 1;
+}
+
+/* Chevron */
+.chevron {
+  flex-shrink: 0;
+  margin-left: var(--ds-spacing-component-sm);
+  color: var(--ds-color-text-subtle);
+  display: flex;
+  align-items: center;
+  transition: transform var(--ds-transition-normal);
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+/* Panel — grid trick for height animation with overflow hidden */
+.panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--ds-transition-normal);
+}
+
+.panelOpen {
+  grid-template-rows: 1fr;
+}
+
+.panelContent {
+  overflow: hidden;
+  padding: 0 var(--ds-spacing-component-md) var(--ds-spacing-component-md);
+  color: var(--ds-color-text-subtle);
+  font-family: var(--ds-typography-fontFamily-body);
+  font-size: var(--ds-typography-fontSize-md);
+  line-height: var(--ds-typography-lineHeight-normal);
 }

--- a/components/Accordion/Accordion.stories.tsx
+++ b/components/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Accordion } from './Accordion';
 
 const meta = {
@@ -6,21 +6,92 @@ const meta = {
   component: Accordion,
   tags: ['autodocs'],
   parameters: {
-    layout: 'centered',
-  },
-  args: {
-    children: 'Accordion content',
-    variant: 'default',
+    layout: 'padded',
   },
 } satisfies Meta<typeof Accordion>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: StoryFn<typeof Accordion> = () => (
+  <Accordion>
+    <Accordion.Item id="item-1" title="What is a design system?">
+      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+    </Accordion.Item>
+    <Accordion.Item id="item-2" title="Why use design tokens?">
+      Design tokens are the single source of truth for your design decisions. They allow you to maintain consistency across platforms and make global changes easily.
+    </Accordion.Item>
+    <Accordion.Item id="item-3" title="How do themes work?">
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+    </Accordion.Item>
+  </Accordion>
+);
 
-export const Outlined: Story = {
-  args: {
-    variant: 'outlined',
-  },
-};
+export const DefaultOpenItem: StoryFn<typeof Accordion> = () => (
+  <Accordion defaultOpen="item-2">
+    <Accordion.Item id="item-1" title="What is a design system?">
+      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+    </Accordion.Item>
+    <Accordion.Item id="item-2" title="Why use design tokens?">
+      Design tokens are the single source of truth for your design decisions. They allow you to maintain consistency across platforms and make global changes easily.
+    </Accordion.Item>
+    <Accordion.Item id="item-3" title="How do themes work?">
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+    </Accordion.Item>
+  </Accordion>
+);
+
+export const AllowMultiple: StoryFn<typeof Accordion> = () => (
+  <Accordion allowMultiple defaultOpen={['item-1', 'item-3']}>
+    <Accordion.Item id="item-1" title="What is a design system?">
+      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+    </Accordion.Item>
+    <Accordion.Item id="item-2" title="Why use design tokens?">
+      Design tokens are the single source of truth for your design decisions. They allow you to maintain consistency across platforms and make global changes easily.
+    </Accordion.Item>
+    <Accordion.Item id="item-3" title="How do themes work?">
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+    </Accordion.Item>
+  </Accordion>
+);
+
+export const Outlined: StoryFn<typeof Accordion> = () => (
+  <Accordion variant="outlined">
+    <Accordion.Item id="item-1" title="What is a design system?">
+      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+    </Accordion.Item>
+    <Accordion.Item id="item-2" title="Why use design tokens?">
+      Design tokens are the single source of truth for your design decisions. They allow you to maintain consistency across platforms and make global changes easily.
+    </Accordion.Item>
+    <Accordion.Item id="item-3" title="How do themes work?">
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+    </Accordion.Item>
+  </Accordion>
+);
+
+export const Flush: StoryFn<typeof Accordion> = () => (
+  <Accordion variant="flush">
+    <Accordion.Item id="item-1" title="What is a design system?">
+      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+    </Accordion.Item>
+    <Accordion.Item id="item-2" title="Why use design tokens?">
+      Design tokens are the single source of truth for your design decisions. They allow you to maintain consistency across platforms and make global changes easily.
+    </Accordion.Item>
+    <Accordion.Item id="item-3" title="How do themes work?">
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+    </Accordion.Item>
+  </Accordion>
+);
+
+export const WithDisabledItem: StoryFn<typeof Accordion> = () => (
+  <Accordion>
+    <Accordion.Item id="item-1" title="What is a design system?">
+      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+    </Accordion.Item>
+    <Accordion.Item id="item-2" title="This item is disabled" disabled>
+      This content is not accessible when the item is disabled.
+    </Accordion.Item>
+    <Accordion.Item id="item-3" title="How do themes work?">
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+    </Accordion.Item>
+  </Accordion>
+);

--- a/components/Accordion/Accordion.tsx
+++ b/components/Accordion/Accordion.tsx
@@ -1,20 +1,122 @@
-import { type HTMLAttributes } from 'react';
+import { type HTMLAttributes, type ReactNode, createContext, useContext, useState, useId } from 'react';
 import { cx } from '../../utils/token.utils';
 import styles from './Accordion.module.css';
 
+export type AccordionVariant = 'default' | 'outlined' | 'flush';
+
 export interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
-  variant?: 'default' | 'outlined';
+  variant?: AccordionVariant;
+  allowMultiple?: boolean;
+  defaultOpen?: string | string[];
+  children: ReactNode;
+}
+
+export interface AccordionItemProps {
+  id?: string;
+  title: ReactNode;
+  disabled?: boolean;
+  children: ReactNode;
+  className?: string;
+}
+
+interface AccordionContextValue {
+  openItems: Set<string>;
+  toggle: (id: string) => void;
+}
+
+const AccordionContext = createContext<AccordionContextValue | null>(null);
+
+function useAccordionContext() {
+  const ctx = useContext(AccordionContext);
+  if (!ctx) throw new Error('Accordion.Item must be used within Accordion');
+  return ctx;
+}
+
+export function AccordionItem({
+  id: idProp,
+  title,
+  disabled = false,
+  children,
+  className,
+}: AccordionItemProps): JSX.Element {
+  const generatedId = useId();
+  const id = idProp ?? generatedId;
+  const { openItems, toggle } = useAccordionContext();
+  const isOpen = openItems.has(id);
+  const triggerId = `${id}-trigger`;
+  const panelId = `${id}-panel`;
+
+  return (
+    <div className={cx(styles.item, disabled && styles.itemDisabled, className)}>
+      <button
+        id={triggerId}
+        type="button"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        disabled={disabled}
+        className={styles.trigger}
+        onClick={() => toggle(id)}
+      >
+        <span className={styles.triggerLabel}>{title}</span>
+        <span className={cx(styles.chevron, isOpen && styles.chevronOpen)} aria-hidden="true">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path
+              d="M4 6l4 4 4-4"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </span>
+      </button>
+      <div
+        id={panelId}
+        role="region"
+        aria-labelledby={triggerId}
+        className={cx(styles.panel, isOpen && styles.panelOpen)}
+      >
+        <div className={styles.panelContent}>{children}</div>
+      </div>
+    </div>
+  );
 }
 
 export function Accordion({
   variant = 'default',
+  allowMultiple = false,
+  defaultOpen,
   className,
   children,
   ...rest
-}: AccordionProps) {
+}: AccordionProps): JSX.Element {
+  const [openItems, setOpenItems] = useState<Set<string>>(() => {
+    if (!defaultOpen) return new Set();
+    return new Set(Array.isArray(defaultOpen) ? defaultOpen : [defaultOpen]);
+  });
+
+  function toggle(id: string) {
+    setOpenItems(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        if (!allowMultiple) next.clear();
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
   return (
-    <div className={cx(styles.root, styles[`variant-${variant}`], className)} {...rest}>
-      {children}
-    </div>
+    <AccordionContext.Provider value={{ openItems, toggle }}>
+      <div className={cx(styles.root, styles[`variant-${variant}`], className)} {...rest}>
+        {children}
+      </div>
+    </AccordionContext.Provider>
   );
 }
+
+Accordion.Item = AccordionItem;
+Accordion.displayName = 'Accordion';
+AccordionItem.displayName = 'Accordion.Item';

--- a/components/index.ts
+++ b/components/index.ts
@@ -64,5 +64,5 @@ export { Icon, NamedIcon, icons } from './Icon/Icon';
 export type { IconProps, IconSize, IconColor, IconName } from './Icon/Icon';
 
 // Accordion
-export { Accordion } from './Accordion/Accordion';
-export type { AccordionProps } from './Accordion/Accordion';
+export { Accordion, AccordionItem } from './Accordion/Accordion';
+export type { AccordionProps, AccordionItemProps, AccordionVariant } from './Accordion/Accordion';


### PR DESCRIPTION
Replaces the generated stub with a fully-featured, accessible Accordion.

- AccordionContext manages open/closed state; Accordion.Item consumes it
- variant prop: default (bordered card), outlined (separate cards), flush (dividers only)
- allowMultiple prop allows multiple panels open simultaneously
- defaultOpen accepts a single id or array of ids
- Smooth expand/collapse via CSS grid-template-rows trick (no JS height measurement)
- Full ARIA: aria-expanded, aria-controls, role="region", aria-labelledby, disabled support
- 6 Storybook stories covering all variants and states
- AccordionItem and AccordionVariant exported from barrel