### PR TITLE
Fix duplicate React instance error in Next.js consumers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "one-design-system",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "one-design-system",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@storybook/addon-a11y": "^8.4.0",
         "@storybook/addon-essentials": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-design-system",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "One Design System — token-driven, theme-aware React component library",
   "type": "module",
   "main": "./dist/one-ds.umd.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,11 +66,12 @@ export default defineConfig(async ({ command }) => {
         fileName: (format) => `one-ds.${format}.js`,
       },
       rollupOptions: {
-        external: ['react', 'react-dom'],
+        external: ['react', 'react-dom', 'react/jsx-runtime'],
         output: {
           globals: {
             react: 'React',
             'react-dom': 'ReactDOM',
+            'react/jsx-runtime': 'ReactJsxRuntime',
           },
         },
       },


### PR DESCRIPTION
Externalize react/jsx-runtime alongside react and react-dom. The automatic JSX transform imports from react/jsx-runtime — without this it was being bundled into the library output, causing Next.js to load two separate React runtimes and throwing ReactCurrentDispatcher errors.

Bundle size: 54 kB → 33 kB (ES), 39 kB → 25 kB (UMD).