### PR TITLE
feat(ci): add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate tokens
+        run: npm run tokens:validate
+
+      - name: Build tokens
+        run: npm run tokens:build
+
+      - name: Check formatting
+        run: npm run format:check
+
+      # Uncomment once ESLint is configured (issue #4)
+      # - name: Lint
+      #   run: npm run lint
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Test with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
+
+      - name: Build library
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # One Design System
 
+[![CI](https://github.com/joeburton/one-design-system/actions/workflows/ci.yml/badge.svg)](https://github.com/joeburton/one-design-system/actions/workflows/ci.yml)
+
 A production-ready, token-driven React + TypeScript component library. Tokens are the single source of truth. Themes are applied via CSS variable overrides — zero component-level logic.
 
 ---


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` to run automated checks on every push to `main` and every pull request
- Adds CI status badge to `README.md`

## What the pipeline does

| Step | Command | Purpose |
|---|---|---|
| Validate tokens | `tokens:validate` | Catch malformed token JSON early |
| Build tokens | `tokens:build` | Ensure generated files are fresh |
| Format check | `format:check` | Enforce Prettier formatting |
| Type check | `typecheck` | Catch TypeScript errors |
| Test with coverage | `test:coverage` | Run Vitest suite and collect coverage |
| Upload coverage | `actions/upload-artifact` | 14-day retention for review |
| Build library | `build` | Verify the Vite build produces valid output |

Concurrency is configured so rapid pushes to the same branch cancel the previous in-progress run.

## Notes for reviewer

- The lint step is present but commented out — it will uncomment once ESLint is configured in #4
- Token build runs before typecheck/tests to ensure the generated `token-vars.generated.ts` is present

## Test plan

- [ ] Open a PR to `main` and confirm all workflow steps appear in the Actions tab
- [ ] Introduce a deliberate type error and confirm `typecheck` step fails
- [ ] Introduce a formatting violation and confirm `format:check` step fails
- [ ] Confirm coverage artifact is uploaded and downloadable after a passing run

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)