### PR TITLE
fix(ci): opt into Node.js 24 for GitHub Actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Adds FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to fix checkout failure (exit code 128) caused by Node.js 20 deprecation on actions/checkout@v4, actions/setup-node@v4, and actions/upload-artifact@v4.