### PR TITLE
fix(ci): upgrade actions to Node.js 24 native versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,12 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -50,7 +47,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage-report

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Generated files — do not format
+styles/tokens.css
+styles/themes/dark.css
+tokens/types/token-vars.generated.ts
+
+# Dependencies and build output
+node_modules
+dist
+coverage

--- a/README.md
+++ b/README.md
@@ -264,17 +264,17 @@ CSS variable prefix: `--ds-` (design system)
 
 ## Scripts Reference
 
-| Script                    | Description                  |
-| ------------------------- | ---------------------------- |
-| `npm run dev`             | Vite dev server              |
-| `npm run build`           | Production build             |
-| `npm run tokens:validate` | Validate token JSON with Zod |
-| `npm run tokens:build`    | Transform tokens → CSS + TS  |
-| `npm run storybook`       | Storybook dev server         |
-| `npm run build-storybook` | Build Storybook static site  |
-| `npm run test`            | Run all tests                |
-| `npm run test:coverage`   | Tests with coverage report   |
-| `npm run typecheck`            | TypeScript type checking               |
-| `npm run generate:component`   | Scaffold a new component with all files|
-| `npm run lint`                 | ESLint                                 |
-| `npm run format`               | Prettier                               |
+| Script                       | Description                             |
+| ---------------------------- | --------------------------------------- |
+| `npm run dev`                | Vite dev server                         |
+| `npm run build`              | Production build                        |
+| `npm run tokens:validate`    | Validate token JSON with Zod            |
+| `npm run tokens:build`       | Transform tokens → CSS + TS             |
+| `npm run storybook`          | Storybook dev server                    |
+| `npm run build-storybook`    | Build Storybook static site             |
+| `npm run test`               | Run all tests                           |
+| `npm run test:coverage`      | Tests with coverage report              |
+| `npm run typecheck`          | TypeScript type checking                |
+| `npm run generate:component` | Scaffold a new component with all files |
+| `npm run lint`               | ESLint                                  |
+| `npm run format`             | Prettier                                |

--- a/components/Accordion/Accordion.stories.tsx
+++ b/components/Accordion/Accordion.stories.tsx
@@ -15,13 +15,16 @@ export default meta;
 export const Default: StoryFn<typeof Accordion> = () => (
   <Accordion>
     <Accordion.Item id="item-1" title="What is a design system?">
-      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+      A design system is a collection of reusable components, guided by clear standards, that can be
+      assembled to build any number of applications.
     </Accordion.Item>
     <Accordion.Item id="item-2" title="Why use design tokens?">
-      Design tokens are the single source of truth for your design decisions. They allow you to maintain consistency across platforms and make global changes easily.
+      Design tokens are the single source of truth for your design decisions. They allow you to
+      maintain consistency across platforms and make global changes easily.
     </Accordion.Item>
     <Accordion.Item id="item-3" title="How do themes work?">
-      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute.
+      No component-level theme logic is needed.
     </Accordion.Item>
   </Accordion>
 );
@@ -29,13 +32,16 @@ export const Default: StoryFn<typeof Accordion> = () => (
 export const DefaultOpenItem: StoryFn<typeof Accordion> = () => (
   <Accordion defaultOpen="item-2">
     <Accordion.Item id="item-1" title="What is a design system?">
-      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+      A design system is a collection of reusable components, guided by clear standards, that can be
+      assembled to build any number of applications.
     </Accordion.Item>
     <Accordion.Item id="item-2" title="Why use design tokens?">
-      Design tokens are the single source of truth for your design decisions. They allow you to maintain consistency across platforms and make global changes easily.
+      Design tokens are the single source of truth for your design decisions. They allow you to
+      maintain consistency across platforms and make global changes easily.
     </Accordion.Item>
     <Accordion.Item id="item-3" title="How do themes work?">
-      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute.
+      No component-level theme logic is needed.
     </Accordion.Item>
   </Accordion>
 );
@@ -43,13 +49,16 @@ export const DefaultOpenItem: StoryFn<typeof Accordion> = () => (
 export const AllowMultiple: StoryFn<typeof Accordion> = () => (
   <Accordion allowMultiple defaultOpen={['item-1', 'item-3']}>
     <Accordion.Item id="item-1" title="What is a design system?">
-      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+      A design system is a collection of reusable components, guided by clear standards, that can be
+      assembled to build any number of applications.
     </Accordion.Item>
     <Accordion.Item id="item-2" title="Why use design tokens?">
-      Design tokens are the single source of truth for your design decisions. They allow you to maintain consistency across platforms and make global changes easily.
+      Design tokens are the single source of truth for your design decisions. They allow you to
+      maintain consistency across platforms and make global changes easily.
     </Accordion.Item>
     <Accordion.Item id="item-3" title="How do themes work?">
-      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute.
+      No component-level theme logic is needed.
     </Accordion.Item>
   </Accordion>
 );
@@ -57,13 +66,16 @@ export const AllowMultiple: StoryFn<typeof Accordion> = () => (
 export const Outlined: StoryFn<typeof Accordion> = () => (
   <Accordion variant="outlined">
     <Accordion.Item id="item-1" title="What is a design system?">
-      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+      A design system is a collection of reusable components, guided by clear standards, that can be
+      assembled to build any number of applications.
     </Accordion.Item>
     <Accordion.Item id="item-2" title="Why use design tokens?">
-      Design tokens are the single source of truth for your design decisions. They allow you to maintain consistency across platforms and make global changes easily.
+      Design tokens are the single source of truth for your design decisions. They allow you to
+      maintain consistency across platforms and make global changes easily.
     </Accordion.Item>
     <Accordion.Item id="item-3" title="How do themes work?">
-      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute.
+      No component-level theme logic is needed.
     </Accordion.Item>
   </Accordion>
 );
@@ -71,13 +83,16 @@ export const Outlined: StoryFn<typeof Accordion> = () => (
 export const Flush: StoryFn<typeof Accordion> = () => (
   <Accordion variant="flush">
     <Accordion.Item id="item-1" title="What is a design system?">
-      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+      A design system is a collection of reusable components, guided by clear standards, that can be
+      assembled to build any number of applications.
     </Accordion.Item>
     <Accordion.Item id="item-2" title="Why use design tokens?">
-      Design tokens are the single source of truth for your design decisions. They allow you to maintain consistency across platforms and make global changes easily.
+      Design tokens are the single source of truth for your design decisions. They allow you to
+      maintain consistency across platforms and make global changes easily.
     </Accordion.Item>
     <Accordion.Item id="item-3" title="How do themes work?">
-      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute.
+      No component-level theme logic is needed.
     </Accordion.Item>
   </Accordion>
 );
@@ -85,13 +100,15 @@ export const Flush: StoryFn<typeof Accordion> = () => (
 export const WithDisabledItem: StoryFn<typeof Accordion> = () => (
   <Accordion>
     <Accordion.Item id="item-1" title="What is a design system?">
-      A design system is a collection of reusable components, guided by clear standards, that can be assembled to build any number of applications.
+      A design system is a collection of reusable components, guided by clear standards, that can be
+      assembled to build any number of applications.
     </Accordion.Item>
     <Accordion.Item id="item-2" title="This item is disabled" disabled>
       This content is not accessible when the item is disabled.
     </Accordion.Item>
     <Accordion.Item id="item-3" title="How do themes work?">
-      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute. No component-level theme logic is needed.
+      Themes are implemented via CSS variable overrides using the <code>data-theme</code> attribute.
+      No component-level theme logic is needed.
     </Accordion.Item>
   </Accordion>
 );
@@ -182,8 +199,8 @@ export const WithInteractiveContent: StoryFn<typeof Accordion> = () => (
   <Accordion defaultOpen="item-1">
     <Accordion.Item id="item-1" title="Panel with interactive elements">
       <p style={{ marginBottom: '12px' }}>
-        Tab through the elements below and confirm focus rings are fully visible and not clipped
-        at the top edge of the panel.
+        Tab through the elements below and confirm focus rings are fully visible and not clipped at
+        the top edge of the panel.
       </p>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <a href="#">Read the documentation →</a>

--- a/components/Accordion/Accordion.tsx
+++ b/components/Accordion/Accordion.tsx
@@ -1,4 +1,11 @@
-import { type HTMLAttributes, type ReactNode, createContext, useContext, useState, useId } from 'react';
+import {
+  type HTMLAttributes,
+  type ReactNode,
+  createContext,
+  useContext,
+  useState,
+  useId,
+} from 'react';
 import { cx } from '../../utils/token.utils';
 import styles from './Accordion.module.css';
 
@@ -98,7 +105,7 @@ export function Accordion({
   });
 
   function toggle(id: string) {
-    setOpenItems(prev => {
+    setOpenItems((prev) => {
       const next = new Set(prev);
       if (next.has(id)) {
         next.delete(id);

--- a/scripts/generate-component.ts
+++ b/scripts/generate-component.ts
@@ -27,7 +27,9 @@ if (!name) {
 
 if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) {
   console.error(`Error: "${name}" is not valid PascalCase.`);
-  console.error('  Component names must start with an uppercase letter and contain only letters and digits.');
+  console.error(
+    '  Component names must start with an uppercase letter and contain only letters and digits.'
+  );
   process.exit(1);
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ function bundleCss(): Plugin {
       const components = readFileSync(resolve(__dirname, 'dist/one-design-system.css'), 'utf-8');
       writeFileSync(
         resolve(__dirname, 'dist/one-design-system.css'),
-        `${tokens}\n${global}\n${components}`,
+        `${tokens}\n${global}\n${components}`
       );
     },
   };
@@ -24,9 +24,7 @@ function bundleCss(): Plugin {
 
 export default defineConfig(async ({ command }) => {
   const isLibraryBuild = command === 'build';
-  const { default: dts } = isLibraryBuild
-    ? await import('vite-plugin-dts')
-    : { default: null };
+  const { default: dts } = isLibraryBuild ? await import('vite-plugin-dts') : { default: null };
 
   return {
     plugins: [


### PR DESCRIPTION
Replace v4 actions (Node.js 20) with versions that run on Node.js 24 natively, fixing the git exit code 128 checkout failure:
  actions/checkout@v4  → v6
  actions/setup-node@v4 → v6
  actions/upload-artifact@v4 → v7

Removes the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 workaround, which was causing the checkout failure rather than fixing it.