### PR TITLE
feat: Textarea, Tooltip, Tabs + token system expansion (P1s #10, #13, #15, #16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,11 @@ All CSS variables are prefixed `--ds-` (design system).
 - `borderRadius` → button, input, card, badge, tooltip
 - `elevation` → none, xs, sm, md, lg, xl (box-shadow values)
 - `transition` → fast (100ms), normal (200ms), slow (300ms)
+- `zIndex` → hide (-1), base (0), raised (1), dropdown (100), sticky (200), overlay (300), modal (400), toast (500), tooltip (600)
+- `opacity` → disabled (0.4), muted (0.6), overlay (0.5)
+- `breakpoint` → sm (640px), md (768px), lg (1024px), xl (1280px), 2xl (1536px) — **JS constants only, not CSS vars** (CSS custom properties cannot be used in media queries — import `breakpoints` from `token-vars.generated.ts`)
+- `animation` → spin (1s), pulse (2s) durations
+- `easing` → easeIn, easeOut, easeInOut (cubic-bezier strings)
 
 ### After editing any token JSON
 

--- a/components/Tabs/Tabs.module.css
+++ b/components/Tabs/Tabs.module.css
@@ -1,0 +1,110 @@
+.root {
+  display: flex;
+}
+
+.orientation-horizontal {
+  flex-direction: column;
+}
+
+.orientation-vertical {
+  flex-direction: row;
+  gap: var(--ds-spacing-component-md);
+}
+
+/* ── Tab List ── */
+
+.tabList {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--ds-color-border-default);
+}
+
+.orientation-vertical .tabList {
+  flex-direction: column;
+  border-bottom: none;
+  border-right: 2px solid var(--ds-color-border-default);
+  min-width: 160px;
+}
+
+/* ── Tab ── */
+
+.tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-spacing-component-xs);
+  padding: var(--ds-spacing-component-sm) var(--ds-spacing-component-md);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  font-family: var(--ds-typography-fontFamily-body);
+  font-size: var(--ds-typography-fontSize-sm);
+  font-weight: var(--ds-typography-fontWeight-medium);
+  color: var(--ds-color-text-subtle);
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    color var(--ds-transition-fast),
+    border-color var(--ds-transition-fast);
+  outline: none;
+}
+.tab:hover:not(.tabDisabled) {
+  color: var(--ds-color-text-default);
+}
+.tab:focus-visible {
+  border-radius: var(--ds-borderRadius-button);
+  box-shadow:
+    0 0 0 2px var(--ds-color-background-default),
+    0 0 0 4px var(--ds-color-border-focus);
+}
+
+.tabActive {
+  color: var(--ds-color-brand-primary);
+  border-bottom-color: var(--ds-color-brand-primary);
+}
+
+.tabDisabled {
+  opacity: var(--ds-opacity-disabled);
+  cursor: not-allowed;
+}
+
+/* Vertical tab indicator */
+.orientation-vertical .tab {
+  border-bottom: none;
+  border-right: 2px solid transparent;
+  margin-bottom: 0;
+  margin-right: -2px;
+  text-align: left;
+  width: 100%;
+  justify-content: flex-start;
+}
+.orientation-vertical .tabActive {
+  border-right-color: var(--ds-color-brand-primary);
+}
+
+/* ── Tab Panel ── */
+
+.tabPanel {
+  padding: var(--ds-spacing-component-md) 0;
+  outline: none;
+  color: var(--ds-color-text-default);
+  font-family: var(--ds-typography-fontFamily-body);
+  font-size: var(--ds-typography-fontSize-sm);
+  line-height: var(--ds-typography-lineHeight-normal);
+}
+.tabPanel:focus-visible {
+  box-shadow:
+    0 0 0 2px var(--ds-color-background-default),
+    0 0 0 4px var(--ds-color-border-focus);
+  border-radius: var(--ds-borderRadius-button);
+}
+
+.orientation-vertical .tabPanel {
+  padding: 0;
+  flex: 1;
+}
+
+.tabPanelActive {
+  display: block;
+}

--- a/components/Tabs/Tabs.stories.tsx
+++ b/components/Tabs/Tabs.stories.tsx
@@ -54,12 +54,20 @@ export const WithDisabledTab: StoryFn<typeof Tabs> = () => (
   <Tabs defaultValue="tab1">
     <TabList>
       <Tab value="tab1">Available</Tab>
-      <Tab value="tab2" disabled>Disabled</Tab>
+      <Tab value="tab2" disabled>
+        Disabled
+      </Tab>
       <Tab value="tab3">Also Available</Tab>
     </TabList>
-    <TabPanel value="tab1"><p>This tab is available.</p></TabPanel>
-    <TabPanel value="tab2"><p>This tab is disabled.</p></TabPanel>
-    <TabPanel value="tab3"><p>This tab is also available.</p></TabPanel>
+    <TabPanel value="tab1">
+      <p>This tab is available.</p>
+    </TabPanel>
+    <TabPanel value="tab2">
+      <p>This tab is disabled.</p>
+    </TabPanel>
+    <TabPanel value="tab3">
+      <p>This tab is also available.</p>
+    </TabPanel>
   </Tabs>
 );
 
@@ -67,16 +75,24 @@ export const Controlled: StoryFn<typeof Tabs> = () => {
   const [value, setValue] = useState('tab1');
   return (
     <div>
-      <p style={{ marginBottom: 16 }}>Active tab: <strong>{value}</strong></p>
+      <p style={{ marginBottom: 16 }}>
+        Active tab: <strong>{value}</strong>
+      </p>
       <Tabs value={value} onChange={setValue}>
         <TabList>
           <Tab value="tab1">First</Tab>
           <Tab value="tab2">Second</Tab>
           <Tab value="tab3">Third</Tab>
         </TabList>
-        <TabPanel value="tab1"><p>First panel content.</p></TabPanel>
-        <TabPanel value="tab2"><p>Second panel content.</p></TabPanel>
-        <TabPanel value="tab3"><p>Third panel content.</p></TabPanel>
+        <TabPanel value="tab1">
+          <p>First panel content.</p>
+        </TabPanel>
+        <TabPanel value="tab2">
+          <p>Second panel content.</p>
+        </TabPanel>
+        <TabPanel value="tab3">
+          <p>Third panel content.</p>
+        </TabPanel>
       </Tabs>
     </div>
   );
@@ -88,8 +104,12 @@ export const LazyPanels: StoryFn<typeof Tabs> = () => (
       <Tab value="tab1">First</Tab>
       <Tab value="tab2">Second (lazy)</Tab>
     </TabList>
-    <TabPanel value="tab1"><p>First panel — always rendered.</p></TabPanel>
-    <TabPanel value="tab2"><p>Second panel — only rendered when active.</p></TabPanel>
+    <TabPanel value="tab1">
+      <p>First panel — always rendered.</p>
+    </TabPanel>
+    <TabPanel value="tab2">
+      <p>Second panel — only rendered when active.</p>
+    </TabPanel>
   </Tabs>
 );
 
@@ -100,9 +120,15 @@ export const KeyboardNavigation: StoryFn<typeof Tabs> = () => (
       <Tab value="tab2">Second</Tab>
       <Tab value="tab3">Third</Tab>
     </TabList>
-    <TabPanel value="tab1"><p>Panel 1</p></TabPanel>
-    <TabPanel value="tab2"><p>Panel 2</p></TabPanel>
-    <TabPanel value="tab3"><p>Panel 3</p></TabPanel>
+    <TabPanel value="tab1">
+      <p>Panel 1</p>
+    </TabPanel>
+    <TabPanel value="tab2">
+      <p>Panel 2</p>
+    </TabPanel>
+    <TabPanel value="tab3">
+      <p>Panel 3</p>
+    </TabPanel>
   </Tabs>
 );
 KeyboardNavigation.storyName = 'Keyboard: Arrow key navigation';

--- a/components/Tabs/Tabs.stories.tsx
+++ b/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,127 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { userEvent, within, expect } from '@storybook/test';
+import { useState } from 'react';
+import { Tabs, TabList, Tab, TabPanel } from './Tabs';
+
+const meta = {
+  title: 'Components/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+
+export const Default: StoryFn<typeof Tabs> = () => (
+  <Tabs defaultValue="tab1">
+    <TabList>
+      <Tab value="tab1">Account</Tab>
+      <Tab value="tab2">Password</Tab>
+      <Tab value="tab3">Notifications</Tab>
+    </TabList>
+    <TabPanel value="tab1">
+      <p>Manage your account settings and preferences.</p>
+    </TabPanel>
+    <TabPanel value="tab2">
+      <p>Update your password and security settings.</p>
+    </TabPanel>
+    <TabPanel value="tab3">
+      <p>Configure how you receive notifications.</p>
+    </TabPanel>
+  </Tabs>
+);
+
+export const Vertical: StoryFn<typeof Tabs> = () => (
+  <Tabs defaultValue="tab1" orientation="vertical" style={{ minHeight: 200 }}>
+    <TabList>
+      <Tab value="tab1">Profile</Tab>
+      <Tab value="tab2">Billing</Tab>
+      <Tab value="tab3">Team</Tab>
+    </TabList>
+    <TabPanel value="tab1">
+      <p>Your profile details and public information.</p>
+    </TabPanel>
+    <TabPanel value="tab2">
+      <p>Manage your subscription and billing details.</p>
+    </TabPanel>
+    <TabPanel value="tab3">
+      <p>Invite and manage your team members.</p>
+    </TabPanel>
+  </Tabs>
+);
+
+export const WithDisabledTab: StoryFn<typeof Tabs> = () => (
+  <Tabs defaultValue="tab1">
+    <TabList>
+      <Tab value="tab1">Available</Tab>
+      <Tab value="tab2" disabled>Disabled</Tab>
+      <Tab value="tab3">Also Available</Tab>
+    </TabList>
+    <TabPanel value="tab1"><p>This tab is available.</p></TabPanel>
+    <TabPanel value="tab2"><p>This tab is disabled.</p></TabPanel>
+    <TabPanel value="tab3"><p>This tab is also available.</p></TabPanel>
+  </Tabs>
+);
+
+export const Controlled: StoryFn<typeof Tabs> = () => {
+  const [value, setValue] = useState('tab1');
+  return (
+    <div>
+      <p style={{ marginBottom: 16 }}>Active tab: <strong>{value}</strong></p>
+      <Tabs value={value} onChange={setValue}>
+        <TabList>
+          <Tab value="tab1">First</Tab>
+          <Tab value="tab2">Second</Tab>
+          <Tab value="tab3">Third</Tab>
+        </TabList>
+        <TabPanel value="tab1"><p>First panel content.</p></TabPanel>
+        <TabPanel value="tab2"><p>Second panel content.</p></TabPanel>
+        <TabPanel value="tab3"><p>Third panel content.</p></TabPanel>
+      </Tabs>
+    </div>
+  );
+};
+
+export const LazyPanels: StoryFn<typeof Tabs> = () => (
+  <Tabs defaultValue="tab1" lazy>
+    <TabList>
+      <Tab value="tab1">First</Tab>
+      <Tab value="tab2">Second (lazy)</Tab>
+    </TabList>
+    <TabPanel value="tab1"><p>First panel — always rendered.</p></TabPanel>
+    <TabPanel value="tab2"><p>Second panel — only rendered when active.</p></TabPanel>
+  </Tabs>
+);
+
+export const KeyboardNavigation: StoryFn<typeof Tabs> = () => (
+  <Tabs defaultValue="tab1">
+    <TabList>
+      <Tab value="tab1">First</Tab>
+      <Tab value="tab2">Second</Tab>
+      <Tab value="tab3">Third</Tab>
+    </TabList>
+    <TabPanel value="tab1"><p>Panel 1</p></TabPanel>
+    <TabPanel value="tab2"><p>Panel 2</p></TabPanel>
+    <TabPanel value="tab3"><p>Panel 3</p></TabPanel>
+  </Tabs>
+);
+KeyboardNavigation.storyName = 'Keyboard: Arrow key navigation';
+KeyboardNavigation.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const firstTab = canvas.getByRole('tab', { name: /first/i });
+
+  await userEvent.tab();
+  await expect(firstTab).toHaveFocus();
+
+  await userEvent.keyboard('{ArrowRight}');
+  await expect(canvas.getByRole('tab', { name: /second/i })).toHaveFocus();
+
+  await userEvent.keyboard('{ArrowRight}');
+  await expect(canvas.getByRole('tab', { name: /third/i })).toHaveFocus();
+
+  await userEvent.keyboard('{Home}');
+  await expect(firstTab).toHaveFocus();
+
+  await userEvent.keyboard('{End}');
+  await expect(canvas.getByRole('tab', { name: /third/i })).toHaveFocus();
+};

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -90,48 +90,13 @@ export interface TabListProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export function TabList({ className, children, ...rest }: TabListProps) {
-  const { orientation, baseId, setActiveValue, registeredTabs } = useTabsContext();
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-    const tabs = registeredTabs.current;
-    const focused = document.activeElement;
-    const focusedIndex = tabs.findIndex(
-      (v) => document.getElementById(`${baseId}-tab-${v}`) === focused
-    );
-    if (focusedIndex === -1) return;
-
-    const isHorizontal = orientation === 'horizontal';
-    const prev = isHorizontal ? 'ArrowLeft' : 'ArrowUp';
-    const next = isHorizontal ? 'ArrowRight' : 'ArrowDown';
-
-    let target = -1;
-    if (e.key === prev) {
-      e.preventDefault();
-      target = focusedIndex === 0 ? tabs.length - 1 : focusedIndex - 1;
-    } else if (e.key === next) {
-      e.preventDefault();
-      target = focusedIndex === tabs.length - 1 ? 0 : focusedIndex + 1;
-    } else if (e.key === 'Home') {
-      e.preventDefault();
-      target = 0;
-    } else if (e.key === 'End') {
-      e.preventDefault();
-      target = tabs.length - 1;
-    }
-
-    if (target !== -1) {
-      const targetEl = document.getElementById(`${baseId}-tab-${tabs[target]}`);
-      targetEl?.focus();
-      setActiveValue(tabs[target]);
-    }
-  };
+  const { orientation } = useTabsContext();
 
   return (
     <div
       role="tablist"
       aria-orientation={orientation}
       className={cx(styles.tabList, className)}
-      onKeyDown={handleKeyDown}
       {...rest}
     >
       {children}
@@ -149,14 +114,45 @@ export interface TabProps extends Omit<HTMLAttributes<HTMLButtonElement>, 'value
   children: ReactNode;
 }
 
-export function Tab({ value, disabled = false, className, children, ...rest }: TabProps) {
-  const { activeValue, setActiveValue, baseId, registeredTabs } = useTabsContext();
+export function Tab({ value, disabled = false, className, children, onKeyDown, ...rest }: TabProps) {
+  const { activeValue, setActiveValue, orientation, baseId, registeredTabs } = useTabsContext();
   const isActive = activeValue === value;
 
-  // Register tab value in order for keyboard navigation
   if (!registeredTabs.current.includes(value)) {
     registeredTabs.current.push(value);
   }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    const tabs = registeredTabs.current;
+    const currentIndex = tabs.indexOf(value);
+    if (currentIndex === -1) return;
+
+    const isHorizontal = orientation === 'horizontal';
+    const prev = isHorizontal ? 'ArrowLeft' : 'ArrowUp';
+    const next = isHorizontal ? 'ArrowRight' : 'ArrowDown';
+
+    let target = -1;
+    if (e.key === prev) {
+      e.preventDefault();
+      target = currentIndex === 0 ? tabs.length - 1 : currentIndex - 1;
+    } else if (e.key === next) {
+      e.preventDefault();
+      target = currentIndex === tabs.length - 1 ? 0 : currentIndex + 1;
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      target = 0;
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      target = tabs.length - 1;
+    }
+
+    if (target !== -1) {
+      document.getElementById(`${baseId}-tab-${tabs[target]}`)?.focus();
+      setActiveValue(tabs[target]);
+    }
+
+    onKeyDown?.(e);
+  };
 
   return (
     <button
@@ -168,6 +164,7 @@ export function Tab({ value, disabled = false, className, children, ...rest }: T
       disabled={disabled}
       className={cx(styles.tab, isActive && styles.tabActive, disabled && styles.tabDisabled, className)}
       onClick={() => !disabled && setActiveValue(value)}
+      onKeyDown={handleKeyDown}
       {...rest}
     >
       {children}

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -1,0 +1,206 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useId,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import { cx } from '../../utils/token.utils';
+import styles from './Tabs.module.css';
+
+export type TabsOrientation = 'horizontal' | 'vertical';
+
+interface TabsContextValue {
+  activeValue: string;
+  setActiveValue: (v: string) => void;
+  orientation: TabsOrientation;
+  baseId: string;
+  lazy: boolean;
+  registeredTabs: React.MutableRefObject<string[]>;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+function useTabsContext() {
+  const ctx = useContext(TabsContext);
+  if (!ctx) throw new Error('Tab/TabPanel must be used inside <Tabs>');
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Tabs
+// ---------------------------------------------------------------------------
+
+export interface TabsProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  defaultValue?: string;
+  value?: string;
+  onChange?: (value: string) => void;
+  orientation?: TabsOrientation;
+  /** Only render the active panel's content */
+  lazy?: boolean;
+  children: ReactNode;
+}
+
+export function Tabs({
+  defaultValue,
+  value: controlledValue,
+  onChange,
+  orientation = 'horizontal',
+  lazy = false,
+  className,
+  children,
+  ...rest
+}: TabsProps) {
+  const [internalValue, setInternalValue] = useState(defaultValue ?? '');
+  const baseId = useId();
+  const registeredTabs = useRef<string[]>([]);
+
+  const activeValue = controlledValue !== undefined ? controlledValue : internalValue;
+
+  const setActiveValue = useCallback(
+    (v: string) => {
+      if (controlledValue === undefined) setInternalValue(v);
+      onChange?.(v);
+    },
+    [controlledValue, onChange]
+  );
+
+  return (
+    <TabsContext.Provider value={{ activeValue, setActiveValue, orientation, baseId, lazy, registeredTabs }}>
+      <div
+        className={cx(styles.root, styles[`orientation-${orientation}`], className)}
+        {...rest}
+      >
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TabList
+// ---------------------------------------------------------------------------
+
+export interface TabListProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export function TabList({ className, children, ...rest }: TabListProps) {
+  const { orientation, baseId, setActiveValue, registeredTabs } = useTabsContext();
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const tabs = registeredTabs.current;
+    const focused = document.activeElement;
+    const focusedIndex = tabs.findIndex(
+      (v) => document.getElementById(`${baseId}-tab-${v}`) === focused
+    );
+    if (focusedIndex === -1) return;
+
+    const isHorizontal = orientation === 'horizontal';
+    const prev = isHorizontal ? 'ArrowLeft' : 'ArrowUp';
+    const next = isHorizontal ? 'ArrowRight' : 'ArrowDown';
+
+    let target = -1;
+    if (e.key === prev) {
+      e.preventDefault();
+      target = focusedIndex === 0 ? tabs.length - 1 : focusedIndex - 1;
+    } else if (e.key === next) {
+      e.preventDefault();
+      target = focusedIndex === tabs.length - 1 ? 0 : focusedIndex + 1;
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      target = 0;
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      target = tabs.length - 1;
+    }
+
+    if (target !== -1) {
+      const targetEl = document.getElementById(`${baseId}-tab-${tabs[target]}`);
+      targetEl?.focus();
+      setActiveValue(tabs[target]);
+    }
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-orientation={orientation}
+      className={cx(styles.tabList, className)}
+      onKeyDown={handleKeyDown}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab
+// ---------------------------------------------------------------------------
+
+export interface TabProps extends Omit<HTMLAttributes<HTMLButtonElement>, 'value'> {
+  value: string;
+  disabled?: boolean;
+  children: ReactNode;
+}
+
+export function Tab({ value, disabled = false, className, children, ...rest }: TabProps) {
+  const { activeValue, setActiveValue, baseId, registeredTabs } = useTabsContext();
+  const isActive = activeValue === value;
+
+  // Register tab value in order for keyboard navigation
+  if (!registeredTabs.current.includes(value)) {
+    registeredTabs.current.push(value);
+  }
+
+  return (
+    <button
+      id={`${baseId}-tab-${value}`}
+      role="tab"
+      aria-selected={isActive}
+      aria-controls={`${baseId}-panel-${value}`}
+      tabIndex={isActive ? 0 : -1}
+      disabled={disabled}
+      className={cx(styles.tab, isActive && styles.tabActive, disabled && styles.tabDisabled, className)}
+      onClick={() => !disabled && setActiveValue(value)}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TabPanel
+// ---------------------------------------------------------------------------
+
+export interface TabPanelProps extends HTMLAttributes<HTMLDivElement> {
+  value: string;
+  children: ReactNode;
+}
+
+export function TabPanel({ value, className, children, ...rest }: TabPanelProps) {
+  const { activeValue, baseId, lazy } = useTabsContext();
+  const isActive = activeValue === value;
+
+  if (lazy && !isActive) return null;
+
+  return (
+    <div
+      id={`${baseId}-panel-${value}`}
+      role="tabpanel"
+      aria-labelledby={`${baseId}-tab-${value}`}
+      hidden={!isActive}
+      tabIndex={0}
+      className={cx(styles.tabPanel, isActive && styles.tabPanelActive, className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -70,11 +70,10 @@ export function Tabs({
   );
 
   return (
-    <TabsContext.Provider value={{ activeValue, setActiveValue, orientation, baseId, lazy, registeredTabs }}>
-      <div
-        className={cx(styles.root, styles[`orientation-${orientation}`], className)}
-        {...rest}
-      >
+    <TabsContext.Provider
+      value={{ activeValue, setActiveValue, orientation, baseId, lazy, registeredTabs }}
+    >
+      <div className={cx(styles.root, styles[`orientation-${orientation}`], className)} {...rest}>
         {children}
       </div>
     </TabsContext.Provider>
@@ -114,7 +113,14 @@ export interface TabProps extends Omit<HTMLAttributes<HTMLButtonElement>, 'value
   children: ReactNode;
 }
 
-export function Tab({ value, disabled = false, className, children, onKeyDown, ...rest }: TabProps) {
+export function Tab({
+  value,
+  disabled = false,
+  className,
+  children,
+  onKeyDown,
+  ...rest
+}: TabProps) {
   const { activeValue, setActiveValue, orientation, baseId, registeredTabs } = useTabsContext();
   const isActive = activeValue === value;
 
@@ -162,7 +168,12 @@ export function Tab({ value, disabled = false, className, children, onKeyDown, .
       aria-controls={`${baseId}-panel-${value}`}
       tabIndex={isActive ? 0 : -1}
       disabled={disabled}
-      className={cx(styles.tab, isActive && styles.tabActive, disabled && styles.tabDisabled, className)}
+      className={cx(
+        styles.tab,
+        isActive && styles.tabActive,
+        disabled && styles.tabDisabled,
+        className
+      )}
       onClick={() => !disabled && setActiveValue(value)}
       onKeyDown={handleKeyDown}
       {...rest}

--- a/components/Textarea/Textarea.module.css
+++ b/components/Textarea/Textarea.module.css
@@ -1,0 +1,125 @@
+.root {
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-component-xs);
+}
+.fullWidth {
+  width: 100%;
+}
+.fullWidth .wrapper {
+  width: 100%;
+}
+
+.label {
+  font-family: var(--ds-typography-fontFamily-body);
+  font-size: var(--ds-typography-fontSize-sm);
+  font-weight: var(--ds-typography-fontWeight-medium);
+  color: var(--ds-color-text-default);
+}
+.required {
+  color: var(--ds-color-status-error);
+}
+
+.wrapper {
+  display: block;
+  position: relative;
+  background-color: var(--ds-color-surface-default);
+  border: 1px solid var(--ds-color-border-default);
+  border-radius: var(--ds-borderRadius-input);
+  transition:
+    border-color var(--ds-transition-fast),
+    box-shadow var(--ds-transition-fast);
+}
+.wrapper:focus-within {
+  border-color: var(--ds-color-border-focus);
+  box-shadow:
+    0 0 0 2px var(--ds-color-background-default),
+    0 0 0 4px var(--ds-color-border-focus);
+}
+
+.size-sm {
+  padding: var(--ds-spacing-component-xs) var(--ds-spacing-component-sm);
+}
+.size-sm .textarea {
+  font-size: var(--ds-typography-fontSize-sm);
+}
+.size-md {
+  padding: var(--ds-spacing-component-sm) var(--ds-spacing-component-md);
+}
+.size-md .textarea {
+  font-size: var(--ds-typography-fontSize-sm);
+}
+.size-lg {
+  padding: var(--ds-spacing-component-sm) var(--ds-spacing-component-md);
+}
+.size-lg .textarea {
+  font-size: var(--ds-typography-fontSize-md);
+}
+
+.status-error {
+  border-color: var(--ds-color-status-errorBorder);
+}
+.status-error:focus-within {
+  border-color: var(--ds-color-status-error);
+  box-shadow:
+    0 0 0 2px var(--ds-color-background-default),
+    0 0 0 4px var(--ds-color-status-errorBorder);
+}
+.status-success {
+  border-color: var(--ds-color-status-successBorder);
+}
+.status-warning {
+  border-color: var(--ds-color-status-warningBorder);
+}
+
+.disabled {
+  opacity: var(--ds-opacity-disabled);
+  cursor: not-allowed;
+  background-color: var(--ds-color-background-muted);
+}
+.disabled .textarea {
+  cursor: not-allowed;
+}
+
+.readOnly .textarea {
+  cursor: default;
+}
+
+.textarea {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 0;
+  margin: 0;
+  font-family: var(--ds-typography-fontFamily-body);
+  font-size: inherit;
+  line-height: var(--ds-typography-lineHeight-normal);
+  color: var(--ds-color-text-default);
+  resize: vertical;
+}
+.textarea::placeholder {
+  color: var(--ds-color-text-muted);
+}
+
+.resize-none .textarea {
+  resize: none;
+}
+.resize-vertical .textarea {
+  resize: vertical;
+}
+.resize-both .textarea {
+  resize: both;
+}
+
+.hint {
+  margin: 0;
+  font-family: var(--ds-typography-fontFamily-body);
+  font-size: var(--ds-typography-fontSize-xs);
+  color: var(--ds-color-text-subtle);
+}
+.hintError {
+  color: var(--ds-color-status-errorText);
+}

--- a/components/Textarea/Textarea.stories.tsx
+++ b/components/Textarea/Textarea.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj, StoryFn } from '@storybook/react';
+import { userEvent, within, expect } from '@storybook/test';
+import { Textarea } from './Textarea';
+
+const meta = {
+  title: 'Components/Textarea',
+  component: Textarea,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    status: { control: 'select', options: ['default', 'error', 'success', 'warning'] },
+    resize: { control: 'select', options: ['none', 'vertical', 'both'] },
+  },
+  args: {
+    size: 'md',
+    status: 'default',
+    resize: 'vertical',
+    placeholder: 'Enter your text here…',
+    rows: 4,
+  },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { label: 'Description', hint: 'Up to 500 characters.' },
+};
+
+export const WithError: Story = {
+  name: 'Error State',
+  args: {
+    label: 'Bio',
+    errorMessage: 'Bio must be at least 20 characters.',
+    defaultValue: 'Too short.',
+  },
+};
+
+export const WithSuccess: Story = {
+  name: 'Success State',
+  args: {
+    label: 'Bio',
+    status: 'success',
+    hint: 'Looks great!',
+    defaultValue: 'I build design systems and love clean component APIs.',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Notes',
+    disabled: true,
+    defaultValue: 'This field cannot be edited.',
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read Only',
+  args: {
+    label: 'Terms',
+    readOnly: true,
+    resize: 'none',
+    defaultValue:
+      'These terms and conditions govern your use of this service. By proceeding you agree to them.',
+  },
+};
+
+export const NoResize: Story = {
+  name: 'Resize: None',
+  args: { label: 'Fixed size', resize: 'none', rows: 3 },
+};
+
+export const ResizeBoth: Story = {
+  name: 'Resize: Both',
+  args: { label: 'Freeform', resize: 'both' },
+};
+
+export const AutoResize: Story = {
+  name: 'Auto Resize',
+  args: {
+    label: 'Auto-expanding',
+    autoResize: true,
+    rows: 2,
+    hint: 'Grows as you type.',
+    placeholder: 'Start typing to see the textarea expand…',
+  },
+};
+
+export const AllSizes: StoryFn<typeof Textarea> = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 16, width: 360 }}>
+    <Textarea size="sm" label="Small" placeholder="Small textarea" rows={2} />
+    <Textarea size="md" label="Medium" placeholder="Medium textarea" rows={3} />
+    <Textarea size="lg" label="Large" placeholder="Large textarea" rows={4} />
+  </div>
+);
+
+export const KeyboardFocus: Story = {
+  name: 'Keyboard: Tab reaches field and accepts input',
+  args: { label: 'Message', placeholder: 'Type something…', rows: 3 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox', { name: /message/i });
+
+    await userEvent.tab();
+    await expect(textarea).toHaveFocus();
+
+    await userEvent.keyboard('Hello from keyboard!');
+    await expect(textarea).toHaveValue('Hello from keyboard!');
+  },
+};

--- a/components/Textarea/Textarea.tsx
+++ b/components/Textarea/Textarea.tsx
@@ -1,0 +1,133 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  type TextareaHTMLAttributes,
+} from 'react';
+import { cx } from '../../utils/token.utils';
+import styles from './Textarea.module.css';
+
+export type TextareaSize = 'sm' | 'md' | 'lg';
+export type TextareaStatus = 'default' | 'error' | 'success' | 'warning';
+export type TextareaResize = 'none' | 'vertical' | 'both';
+
+export interface TextareaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size'> {
+  label?: string;
+  hint?: string;
+  errorMessage?: string;
+  status?: TextareaStatus;
+  size?: TextareaSize;
+  resize?: TextareaResize;
+  autoResize?: boolean;
+  fullWidth?: boolean;
+}
+
+function adjustHeight(el: HTMLTextAreaElement) {
+  el.style.height = 'auto';
+  el.style.height = `${el.scrollHeight}px`;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  {
+    label,
+    hint,
+    errorMessage,
+    status = 'default',
+    size = 'md',
+    resize = 'vertical',
+    autoResize = false,
+    fullWidth = false,
+    disabled,
+    readOnly,
+    id: providedId,
+    className,
+    onInput,
+    'aria-describedby': ariaDescribedBy,
+    ...rest
+  },
+  ref
+) {
+  const genId = useId();
+  const id = providedId ?? genId;
+  const hintId = `${id}-hint`;
+  const errorId = `${id}-error`;
+  const effectiveStatus = errorMessage ? 'error' : status;
+  const effectiveResize = autoResize ? 'none' : resize;
+  const describedBy =
+    [errorMessage ? errorId : null, hint ? hintId : null, ariaDescribedBy ?? null]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+  const internalRef = useRef<HTMLTextAreaElement | null>(null);
+  const callbackRef = useCallback(
+    (el: HTMLTextAreaElement | null) => {
+      internalRef.current = el;
+      if (typeof ref === 'function') ref(el);
+      else if (ref) (ref as React.MutableRefObject<HTMLTextAreaElement | null>).current = el;
+    },
+    [ref]
+  );
+
+  useEffect(() => {
+    if (autoResize && internalRef.current) {
+      adjustHeight(internalRef.current);
+    }
+  }, [autoResize]);
+
+  const handleInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+    if (autoResize) adjustHeight(e.currentTarget);
+    onInput?.(e);
+  };
+
+  return (
+    <div className={cx(styles.root, fullWidth && styles.fullWidth, className)}>
+      {label && (
+        <label htmlFor={id} className={styles.label}>
+          {label}
+          {rest.required && (
+            <span className={styles.required} aria-hidden="true">
+              {' '}
+              *
+            </span>
+          )}
+        </label>
+      )}
+      <div
+        className={cx(
+          styles.wrapper,
+          styles[`size-${size}`],
+          styles[`status-${effectiveStatus}`],
+          styles[`resize-${effectiveResize}`],
+          disabled && styles.disabled,
+          readOnly && styles.readOnly
+        )}
+      >
+        <textarea
+          ref={callbackRef}
+          id={id}
+          disabled={disabled}
+          readOnly={readOnly}
+          aria-invalid={effectiveStatus === 'error' ? true : undefined}
+          aria-describedby={describedBy}
+          className={styles.textarea}
+          onInput={handleInput}
+          {...rest}
+        />
+      </div>
+      {errorMessage && (
+        <p id={errorId} className={cx(styles.hint, styles.hintError)} role="alert">
+          {errorMessage}
+        </p>
+      )}
+      {!errorMessage && hint && (
+        <p id={hintId} className={styles.hint}>
+          {hint}
+        </p>
+      )}
+    </div>
+  );
+});
+
+Textarea.displayName = 'Textarea';

--- a/components/Tooltip/Tooltip.module.css
+++ b/components/Tooltip/Tooltip.module.css
@@ -1,5 +1,3 @@
---tooltip-gap: var(--ds-spacing-component-xs);
-
 .root {
   position: relative;
   display: inline-block;

--- a/components/Tooltip/Tooltip.module.css
+++ b/components/Tooltip/Tooltip.module.css
@@ -1,0 +1,71 @@
+--tooltip-gap: var(--ds-spacing-component-xs);
+
+.root {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip {
+  position: absolute;
+  z-index: var(--ds-zIndex-tooltip);
+  max-width: 240px;
+  padding: var(--ds-spacing-component-xs) var(--ds-spacing-component-sm);
+  background-color: var(--ds-color-background-emphasis);
+  color: var(--ds-color-text-onEmphasis);
+  border-radius: var(--ds-borderRadius-tooltip);
+  box-shadow: var(--ds-elevation-sm);
+  font-family: var(--ds-typography-fontFamily-body);
+  font-size: var(--ds-typography-fontSize-xs);
+  line-height: var(--ds-typography-lineHeight-normal);
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  scale: 0.95;
+  transition:
+    opacity var(--ds-transition-fast),
+    scale var(--ds-transition-fast);
+}
+
+.visible {
+  opacity: 1;
+  scale: 1;
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip {
+    transition: none;
+  }
+}
+
+/* Placement: top (default) */
+.placement-top {
+  bottom: calc(100% + var(--ds-spacing-component-xs));
+  left: 50%;
+  transform: translateX(-50%);
+  transform-origin: bottom center;
+}
+
+/* Placement: bottom */
+.placement-bottom {
+  top: calc(100% + var(--ds-spacing-component-xs));
+  left: 50%;
+  transform: translateX(-50%);
+  transform-origin: top center;
+}
+
+/* Placement: left */
+.placement-left {
+  right: calc(100% + var(--ds-spacing-component-xs));
+  top: 50%;
+  transform: translateY(-50%);
+  transform-origin: right center;
+}
+
+/* Placement: right */
+.placement-right {
+  left: calc(100% + var(--ds-spacing-component-xs));
+  top: 50%;
+  transform: translateY(-50%);
+  transform-origin: left center;
+}

--- a/components/Tooltip/Tooltip.stories.tsx
+++ b/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj, StoryFn } from '@storybook/react';
+import { userEvent, within, expect } from '@storybook/test';
+import { Tooltip } from './Tooltip';
+import { Button } from '../Button/Button';
+
+const meta = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    placement: { control: 'select', options: ['top', 'bottom', 'left', 'right'] },
+  },
+  args: {
+    content: 'This is a tooltip',
+    placement: 'top',
+    delay: 0,
+  },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: <Button>Hover me</Button> },
+};
+
+export const AllPlacements: StoryFn<typeof Tooltip> = () => (
+  <div style={{ display: 'flex', gap: 32, padding: 64 }}>
+    <Tooltip content="Above" placement="top">
+      <Button variant="secondary">Top</Button>
+    </Tooltip>
+    <Tooltip content="Below" placement="bottom">
+      <Button variant="secondary">Bottom</Button>
+    </Tooltip>
+    <Tooltip content="To the left" placement="left">
+      <Button variant="secondary">Left</Button>
+    </Tooltip>
+    <Tooltip content="To the right" placement="right">
+      <Button variant="secondary">Right</Button>
+    </Tooltip>
+  </div>
+);
+
+export const WithDelay: Story = {
+  name: 'With Delay (300ms)',
+  args: {
+    content: 'Appeared after 300ms',
+    delay: 300,
+    children: <Button variant="secondary">Hover (delayed)</Button>,
+  },
+};
+
+export const OnIcon: StoryFn<typeof Tooltip> = () => (
+  <Tooltip content="Delete this item" placement="top">
+    <button aria-label="Delete" style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8 }}>
+      🗑️
+    </button>
+  </Tooltip>
+);
+
+export const KeyboardFocus: Story = {
+  name: 'Keyboard: Focus shows tooltip',
+  args: { content: 'Shown on focus', children: <Button>Focus me</Button> },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: /focus me/i });
+
+    await userEvent.tab();
+    await expect(button).toHaveFocus();
+    await expect(button).toHaveAttribute('aria-describedby');
+  },
+};

--- a/components/Tooltip/Tooltip.stories.tsx
+++ b/components/Tooltip/Tooltip.stories.tsx
@@ -53,7 +53,10 @@ export const WithDelay: Story = {
 
 export const OnIcon: StoryFn<typeof Tooltip> = () => (
   <Tooltip content="Delete this item" placement="top">
-    <button aria-label="Delete" style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8 }}>
+    <button
+      aria-label="Delete"
+      style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 8 }}
+    >
       🗑️
     </button>
   </Tooltip>

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -60,11 +60,7 @@ export function Tooltip({ content, placement = 'top', delay = 0, children }: Too
         id={tooltipId}
         role="tooltip"
         aria-hidden={!visible}
-        className={cx(
-          styles.tooltip,
-          styles[`placement-${placement}`],
-          visible && styles.visible
-        )}
+        className={cx(styles.tooltip, styles[`placement-${placement}`], visible && styles.visible)}
       >
         {content}
       </span>

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,73 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useId,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import { cx } from '../../utils/token.utils';
+import styles from './Tooltip.module.css';
+
+export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export interface TooltipProps {
+  content: ReactNode;
+  placement?: TooltipPlacement;
+  /** Delay in ms before the tooltip appears */
+  delay?: number;
+  children: ReactElement;
+}
+
+export function Tooltip({ content, placement = 'top', delay = 0, children }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const tooltipId = useId();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (delay > 0) {
+      timerRef.current = setTimeout(() => setVisible(true), delay);
+    } else {
+      setVisible(true);
+    }
+  };
+
+  const hide = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setVisible(false);
+  };
+
+  const child = Children.only(children);
+  if (!isValidElement(child)) return child;
+
+  const trigger = cloneElement(child as ReactElement<Record<string, unknown>>, {
+    'aria-describedby': visible ? tooltipId : undefined,
+  });
+
+  return (
+    <span
+      className={styles.root}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {trigger}
+      <span
+        id={tooltipId}
+        role="tooltip"
+        aria-hidden={!visible}
+        className={cx(
+          styles.tooltip,
+          styles[`placement-${placement}`],
+          visible && styles.visible
+        )}
+      >
+        {content}
+      </span>
+    </span>
+  );
+}

--- a/components/index.ts
+++ b/components/index.ts
@@ -82,3 +82,15 @@ export type { CheckboxProps } from './Checkbox/Checkbox';
 // Radio
 export { Radio, RadioGroup } from './Radio/Radio';
 export type { RadioProps, RadioGroupProps } from './Radio/Radio';
+
+// Textarea
+export { Textarea } from './Textarea/Textarea';
+export type { TextareaProps, TextareaSize, TextareaStatus, TextareaResize } from './Textarea/Textarea';
+
+// Tooltip
+export { Tooltip } from './Tooltip/Tooltip';
+export type { TooltipProps, TooltipPlacement } from './Tooltip/Tooltip';
+
+// Tabs
+export { Tabs, TabList, Tab, TabPanel } from './Tabs/Tabs';
+export type { TabsProps, TabListProps, TabProps, TabPanelProps, TabsOrientation } from './Tabs/Tabs';

--- a/components/index.ts
+++ b/components/index.ts
@@ -85,7 +85,12 @@ export type { RadioProps, RadioGroupProps } from './Radio/Radio';
 
 // Textarea
 export { Textarea } from './Textarea/Textarea';
-export type { TextareaProps, TextareaSize, TextareaStatus, TextareaResize } from './Textarea/Textarea';
+export type {
+  TextareaProps,
+  TextareaSize,
+  TextareaStatus,
+  TextareaResize,
+} from './Textarea/Textarea';
 
 // Tooltip
 export { Tooltip } from './Tooltip/Tooltip';
@@ -93,4 +98,10 @@ export type { TooltipProps, TooltipPlacement } from './Tooltip/Tooltip';
 
 // Tabs
 export { Tabs, TabList, Tab, TabPanel } from './Tabs/Tabs';
-export type { TabsProps, TabListProps, TabProps, TabPanelProps, TabsOrientation } from './Tabs/Tabs';
+export type {
+  TabsProps,
+  TabListProps,
+  TabProps,
+  TabPanelProps,
+  TabsOrientation,
+} from './Tabs/Tabs';

--- a/scripts/transform-tokens.ts
+++ b/scripts/transform-tokens.ts
@@ -101,7 +101,14 @@ function renderTypedVars(vars: FlatMap): string {
     .map((name) => `  '${name}': \`var(${name})\``)
     .join(',\n');
 
-  return `/**\n * AUTO-GENERATED — do not edit.\n * Run: npm run tokens:build\n */\n\n${consts}\n\nexport const tokenVars = {\n${map}\n} as const;\n\nexport type TokenVarKey = keyof typeof tokenVars;\nexport type TokenVarValue = (typeof tokenVars)[TokenVarKey];\n`;
+  // Breakpoints need actual values exported as JS constants — CSS custom properties
+  // cannot be used in media queries.
+  const bpEntries = Object.entries(vars).filter(([k]) => k.startsWith('--ds-breakpoint-'));
+  const breakpointSection = bpEntries.length
+    ? `\n// Breakpoints as JS constants (CSS custom properties cannot be used in media queries)\nexport const breakpoints = {\n${bpEntries.map(([k, v]) => `  '${k.replace('--ds-breakpoint-', '')}': '${v}'`).join(',\n')}\n} as const;\n\nexport type BreakpointKey = keyof typeof breakpoints;\n`
+    : '';
+
+  return `/**\n * AUTO-GENERATED — do not edit.\n * Run: npm run tokens:build\n */\n\n${consts}\n\nexport const tokenVars = {\n${map}\n} as const;\n\nexport type TokenVarKey = keyof typeof tokenVars;\nexport type TokenVarValue = (typeof tokenVars)[TokenVarKey];\n${breakpointSection}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -87,6 +87,28 @@
   --ds-duration-fast: 100ms;
   --ds-duration-normal: 200ms;
   --ds-duration-slow: 300ms;
+  --ds-zIndex-hide: -1;
+  --ds-zIndex-base: 0;
+  --ds-zIndex-raised: 1;
+  --ds-zIndex-dropdown: 100;
+  --ds-zIndex-sticky: 200;
+  --ds-zIndex-overlay: 300;
+  --ds-zIndex-modal: 400;
+  --ds-zIndex-toast: 500;
+  --ds-zIndex-tooltip: 600;
+  --ds-opacity-disabled: 0.4;
+  --ds-opacity-muted: 0.6;
+  --ds-opacity-overlay: 0.5;
+  --ds-breakpoint-sm: 640px;
+  --ds-breakpoint-md: 768px;
+  --ds-breakpoint-lg: 1024px;
+  --ds-breakpoint-xl: 1280px;
+  --ds-breakpoint-2xl: 1536px;
+  --ds-animation-spin: 1s;
+  --ds-animation-pulse: 2s;
+  --ds-easing-easeIn: cubic-bezier(0.4, 0, 1, 1);
+  --ds-easing-easeOut: cubic-bezier(0, 0, 0.2, 1);
+  --ds-easing-easeInOut: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* ── Semantic Tokens: Light (default) ── */
@@ -181,4 +203,26 @@
   --ds-transition-fast: 100ms cubic-bezier(0, 0, 0.2, 1);
   --ds-transition-normal: 200ms cubic-bezier(0.4, 0, 0.2, 1);
   --ds-transition-slow: 300ms cubic-bezier(0.4, 0, 0.2, 1);
+  --ds-zIndex-hide: -1;
+  --ds-zIndex-base: 0;
+  --ds-zIndex-raised: 1;
+  --ds-zIndex-dropdown: 100;
+  --ds-zIndex-sticky: 200;
+  --ds-zIndex-overlay: 300;
+  --ds-zIndex-modal: 400;
+  --ds-zIndex-toast: 500;
+  --ds-zIndex-tooltip: 600;
+  --ds-opacity-disabled: 0.4;
+  --ds-opacity-muted: 0.6;
+  --ds-opacity-overlay: 0.5;
+  --ds-breakpoint-sm: 640px;
+  --ds-breakpoint-md: 768px;
+  --ds-breakpoint-lg: 1024px;
+  --ds-breakpoint-xl: 1280px;
+  --ds-breakpoint-2xl: 1536px;
+  --ds-animation-spin: 1s;
+  --ds-animation-pulse: 2s;
+  --ds-easing-easeIn: cubic-bezier(0.4, 0, 1, 1);
+  --ds-easing-easeOut: cubic-bezier(0, 0, 0.2, 1);
+  --ds-easing-easeInOut: cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/tests/Tabs.test.tsx
+++ b/tests/Tabs.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tabs, TabList, Tab, TabPanel } from '../components/Tabs/Tabs';
+
+function renderTabs(defaultValue = 'a') {
+  return render(
+    <Tabs defaultValue={defaultValue}>
+      <TabList>
+        <Tab value="a">Alpha</Tab>
+        <Tab value="b">Beta</Tab>
+        <Tab value="c" disabled>Gamma</Tab>
+      </TabList>
+      <TabPanel value="a">Panel A</TabPanel>
+      <TabPanel value="b">Panel B</TabPanel>
+      <TabPanel value="c">Panel C</TabPanel>
+    </Tabs>
+  );
+}
+
+const setup = (jsx: React.ReactElement) => ({
+  user: userEvent.setup(),
+  ...render(jsx),
+});
+
+describe('Tabs', () => {
+  describe('rendering', () => {
+    it('renders a tablist', () => {
+      renderTabs();
+      expect(screen.getByRole('tablist')).toBeInTheDocument();
+    });
+
+    it('renders all tab buttons', () => {
+      renderTabs();
+      expect(screen.getAllByRole('tab')).toHaveLength(3);
+    });
+
+    it('renders all tab panels', () => {
+      renderTabs();
+      expect(screen.getAllByRole('tabpanel', { hidden: true })).toHaveLength(3);
+    });
+
+    it('shows the default active tab panel', () => {
+      renderTabs('a');
+      expect(screen.getByRole('tabpanel', { name: /alpha/i })).not.toHaveAttribute('hidden');
+    });
+
+    it('hides non-active panels', () => {
+      renderTabs('a');
+      const panels = screen.getAllByRole('tabpanel', { hidden: true });
+      const betaPanel = panels.find((p) => p.textContent?.includes('Panel B'))!;
+      expect(betaPanel).toHaveAttribute('hidden');
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('sets aria-selected on the active tab', () => {
+      renderTabs('a');
+      expect(screen.getByRole('tab', { name: /alpha/i })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('sets aria-selected=false on inactive tabs', () => {
+      renderTabs('a');
+      expect(screen.getByRole('tab', { name: /beta/i })).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('wires aria-controls from tab to panel', () => {
+      renderTabs('a');
+      const tab = screen.getByRole('tab', { name: /alpha/i });
+      const panelId = tab.getAttribute('aria-controls')!;
+      expect(document.getElementById(panelId)).toHaveTextContent('Panel A');
+    });
+
+    it('wires aria-labelledby from panel to tab', () => {
+      renderTabs('a');
+      const panel = screen.getByRole('tabpanel', { name: /alpha/i });
+      const tabId = panel.getAttribute('aria-labelledby')!;
+      expect(document.getElementById(tabId)).toHaveTextContent('Alpha');
+    });
+
+    it('sets tabIndex=0 on active tab and -1 on others', () => {
+      renderTabs('a');
+      expect(screen.getByRole('tab', { name: /alpha/i })).toHaveAttribute('tabindex', '0');
+      expect(screen.getByRole('tab', { name: /beta/i })).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('marks disabled tab as disabled', () => {
+      renderTabs();
+      expect(screen.getByRole('tab', { name: /gamma/i })).toBeDisabled();
+    });
+  });
+
+  describe('click interactions', () => {
+    it('activates a tab on click', async () => {
+      const { user } = setup(<Tabs defaultValue="a"><TabList><Tab value="a">A</Tab><Tab value="b">B</Tab></TabList><TabPanel value="a">Panel A</TabPanel><TabPanel value="b">Panel B</TabPanel></Tabs>);
+      await user.click(screen.getByRole('tab', { name: /^b$/i }));
+      expect(screen.getByRole('tab', { name: /^b$/i })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('tabpanel', { name: /^b$/i })).not.toHaveAttribute('hidden');
+    });
+
+    it('calls onChange when a tab is clicked', async () => {
+      const onChange = vi.fn();
+      const { user } = setup(
+        <Tabs defaultValue="a" onChange={onChange}>
+          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab></TabList>
+          <TabPanel value="a">Panel A</TabPanel>
+          <TabPanel value="b">Panel B</TabPanel>
+        </Tabs>
+      );
+      await user.click(screen.getByRole('tab', { name: /^b$/i }));
+      expect(onChange).toHaveBeenCalledWith('b');
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('moves focus right with ArrowRight', async () => {
+      const { user } = setup(
+        <Tabs defaultValue="a">
+          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab><Tab value="c">C</Tab></TabList>
+          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel><TabPanel value="c">C</TabPanel>
+        </Tabs>
+      );
+      await user.tab();
+      expect(screen.getByRole('tab', { name: /^a$/i })).toHaveFocus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('tab', { name: /^b$/i })).toHaveFocus();
+    });
+
+    it('moves focus left with ArrowLeft', async () => {
+      const { user } = setup(
+        <Tabs defaultValue="b">
+          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab><Tab value="c">C</Tab></TabList>
+          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel><TabPanel value="c">C</TabPanel>
+        </Tabs>
+      );
+      await user.tab();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('tab', { name: /^a$/i })).toHaveFocus();
+    });
+
+    it('wraps from last to first with ArrowRight', async () => {
+      const { user } = setup(
+        <Tabs defaultValue="c">
+          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab><Tab value="c">C</Tab></TabList>
+          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel><TabPanel value="c">C</TabPanel>
+        </Tabs>
+      );
+      await user.tab();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('tab', { name: /^a$/i })).toHaveFocus();
+    });
+
+    it('jumps to first tab with Home', async () => {
+      const { user } = setup(
+        <Tabs defaultValue="c">
+          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab><Tab value="c">C</Tab></TabList>
+          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel><TabPanel value="c">C</TabPanel>
+        </Tabs>
+      );
+      await user.tab();
+      await user.keyboard('{Home}');
+      expect(screen.getByRole('tab', { name: /^a$/i })).toHaveFocus();
+    });
+
+    it('jumps to last tab with End', async () => {
+      const { user } = setup(
+        <Tabs defaultValue="a">
+          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab><Tab value="c">C</Tab></TabList>
+          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel><TabPanel value="c">C</TabPanel>
+        </Tabs>
+      );
+      await user.tab();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('tab', { name: /^c$/i })).toHaveFocus();
+    });
+
+    it('uses ArrowDown/ArrowUp for vertical orientation', async () => {
+      const { user } = setup(
+        <Tabs defaultValue="a" orientation="vertical">
+          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab></TabList>
+          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel>
+        </Tabs>
+      );
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('tab', { name: /^b$/i })).toHaveFocus();
+    });
+  });
+
+  describe('lazy rendering', () => {
+    it('does not render inactive panels when lazy=true', () => {
+      render(
+        <Tabs defaultValue="a" lazy>
+          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab></TabList>
+          <TabPanel value="a">Panel A</TabPanel>
+          <TabPanel value="b">Panel B</TabPanel>
+        </Tabs>
+      );
+      expect(screen.queryByText('Panel B')).not.toBeInTheDocument();
+    });
+
+    it('renders panel content when tab is activated with lazy=true', async () => {
+      const { user } = setup(
+        <Tabs defaultValue="a" lazy>
+          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab></TabList>
+          <TabPanel value="a">Panel A</TabPanel>
+          <TabPanel value="b">Panel B</TabPanel>
+        </Tabs>
+      );
+      await user.click(screen.getByRole('tab', { name: /^b$/i }));
+      expect(screen.getByText('Panel B')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/Tabs.test.tsx
+++ b/tests/Tabs.test.tsx
@@ -9,7 +9,9 @@ function renderTabs(defaultValue = 'a') {
       <TabList>
         <Tab value="a">Alpha</Tab>
         <Tab value="b">Beta</Tab>
-        <Tab value="c" disabled>Gamma</Tab>
+        <Tab value="c" disabled>
+          Gamma
+        </Tab>
       </TabList>
       <TabPanel value="a">Panel A</TabPanel>
       <TabPanel value="b">Panel B</TabPanel>
@@ -92,7 +94,16 @@ describe('Tabs', () => {
 
   describe('click interactions', () => {
     it('activates a tab on click', async () => {
-      const { user } = setup(<Tabs defaultValue="a"><TabList><Tab value="a">A</Tab><Tab value="b">B</Tab></TabList><TabPanel value="a">Panel A</TabPanel><TabPanel value="b">Panel B</TabPanel></Tabs>);
+      const { user } = setup(
+        <Tabs defaultValue="a">
+          <TabList>
+            <Tab value="a">A</Tab>
+            <Tab value="b">B</Tab>
+          </TabList>
+          <TabPanel value="a">Panel A</TabPanel>
+          <TabPanel value="b">Panel B</TabPanel>
+        </Tabs>
+      );
       await user.click(screen.getByRole('tab', { name: /^b$/i }));
       expect(screen.getByRole('tab', { name: /^b$/i })).toHaveAttribute('aria-selected', 'true');
       expect(screen.getByRole('tabpanel', { name: /^b$/i })).not.toHaveAttribute('hidden');
@@ -102,7 +113,10 @@ describe('Tabs', () => {
       const onChange = vi.fn();
       const { user } = setup(
         <Tabs defaultValue="a" onChange={onChange}>
-          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab></TabList>
+          <TabList>
+            <Tab value="a">A</Tab>
+            <Tab value="b">B</Tab>
+          </TabList>
           <TabPanel value="a">Panel A</TabPanel>
           <TabPanel value="b">Panel B</TabPanel>
         </Tabs>
@@ -116,8 +130,14 @@ describe('Tabs', () => {
     it('moves focus right with ArrowRight', async () => {
       const { user } = setup(
         <Tabs defaultValue="a">
-          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab><Tab value="c">C</Tab></TabList>
-          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel><TabPanel value="c">C</TabPanel>
+          <TabList>
+            <Tab value="a">A</Tab>
+            <Tab value="b">B</Tab>
+            <Tab value="c">C</Tab>
+          </TabList>
+          <TabPanel value="a">A</TabPanel>
+          <TabPanel value="b">B</TabPanel>
+          <TabPanel value="c">C</TabPanel>
         </Tabs>
       );
       await user.tab();
@@ -129,8 +149,14 @@ describe('Tabs', () => {
     it('moves focus left with ArrowLeft', async () => {
       const { user } = setup(
         <Tabs defaultValue="b">
-          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab><Tab value="c">C</Tab></TabList>
-          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel><TabPanel value="c">C</TabPanel>
+          <TabList>
+            <Tab value="a">A</Tab>
+            <Tab value="b">B</Tab>
+            <Tab value="c">C</Tab>
+          </TabList>
+          <TabPanel value="a">A</TabPanel>
+          <TabPanel value="b">B</TabPanel>
+          <TabPanel value="c">C</TabPanel>
         </Tabs>
       );
       await user.tab();
@@ -141,8 +167,14 @@ describe('Tabs', () => {
     it('wraps from last to first with ArrowRight', async () => {
       const { user } = setup(
         <Tabs defaultValue="c">
-          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab><Tab value="c">C</Tab></TabList>
-          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel><TabPanel value="c">C</TabPanel>
+          <TabList>
+            <Tab value="a">A</Tab>
+            <Tab value="b">B</Tab>
+            <Tab value="c">C</Tab>
+          </TabList>
+          <TabPanel value="a">A</TabPanel>
+          <TabPanel value="b">B</TabPanel>
+          <TabPanel value="c">C</TabPanel>
         </Tabs>
       );
       await user.tab();
@@ -153,8 +185,14 @@ describe('Tabs', () => {
     it('jumps to first tab with Home', async () => {
       const { user } = setup(
         <Tabs defaultValue="c">
-          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab><Tab value="c">C</Tab></TabList>
-          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel><TabPanel value="c">C</TabPanel>
+          <TabList>
+            <Tab value="a">A</Tab>
+            <Tab value="b">B</Tab>
+            <Tab value="c">C</Tab>
+          </TabList>
+          <TabPanel value="a">A</TabPanel>
+          <TabPanel value="b">B</TabPanel>
+          <TabPanel value="c">C</TabPanel>
         </Tabs>
       );
       await user.tab();
@@ -165,8 +203,14 @@ describe('Tabs', () => {
     it('jumps to last tab with End', async () => {
       const { user } = setup(
         <Tabs defaultValue="a">
-          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab><Tab value="c">C</Tab></TabList>
-          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel><TabPanel value="c">C</TabPanel>
+          <TabList>
+            <Tab value="a">A</Tab>
+            <Tab value="b">B</Tab>
+            <Tab value="c">C</Tab>
+          </TabList>
+          <TabPanel value="a">A</TabPanel>
+          <TabPanel value="b">B</TabPanel>
+          <TabPanel value="c">C</TabPanel>
         </Tabs>
       );
       await user.tab();
@@ -177,8 +221,12 @@ describe('Tabs', () => {
     it('uses ArrowDown/ArrowUp for vertical orientation', async () => {
       const { user } = setup(
         <Tabs defaultValue="a" orientation="vertical">
-          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab></TabList>
-          <TabPanel value="a">A</TabPanel><TabPanel value="b">B</TabPanel>
+          <TabList>
+            <Tab value="a">A</Tab>
+            <Tab value="b">B</Tab>
+          </TabList>
+          <TabPanel value="a">A</TabPanel>
+          <TabPanel value="b">B</TabPanel>
         </Tabs>
       );
       await user.tab();
@@ -191,7 +239,10 @@ describe('Tabs', () => {
     it('does not render inactive panels when lazy=true', () => {
       render(
         <Tabs defaultValue="a" lazy>
-          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab></TabList>
+          <TabList>
+            <Tab value="a">A</Tab>
+            <Tab value="b">B</Tab>
+          </TabList>
           <TabPanel value="a">Panel A</TabPanel>
           <TabPanel value="b">Panel B</TabPanel>
         </Tabs>
@@ -202,7 +253,10 @@ describe('Tabs', () => {
     it('renders panel content when tab is activated with lazy=true', async () => {
       const { user } = setup(
         <Tabs defaultValue="a" lazy>
-          <TabList><Tab value="a">A</Tab><Tab value="b">B</Tab></TabList>
+          <TabList>
+            <Tab value="a">A</Tab>
+            <Tab value="b">B</Tab>
+          </TabList>
           <TabPanel value="a">Panel A</TabPanel>
           <TabPanel value="b">Panel B</TabPanel>
         </Tabs>

--- a/tests/Textarea.test.tsx
+++ b/tests/Textarea.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Textarea } from '../components/Textarea/Textarea';
+
+const setup = (jsx: React.ReactElement) => ({
+  user: userEvent.setup(),
+  ...render(jsx),
+});
+
+describe('Textarea', () => {
+  describe('rendering', () => {
+    it('renders a textarea element', () => {
+      render(<Textarea />);
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('renders with a label when provided', () => {
+      render(<Textarea label="Description" />);
+      expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    });
+
+    it('associates label with textarea via htmlFor', () => {
+      render(<Textarea label="Bio" id="bio" />);
+      const label = screen.getByText('Bio');
+      const textarea = screen.getByRole('textbox');
+      expect(label).toHaveAttribute('for', 'bio');
+      expect(textarea).toHaveAttribute('id', 'bio');
+    });
+
+    it('renders hint text', () => {
+      render(<Textarea hint="Up to 500 characters" />);
+      expect(screen.getByText('Up to 500 characters')).toBeInTheDocument();
+    });
+
+    it('renders error message and suppresses hint', () => {
+      render(<Textarea hint="Normal hint" errorMessage="This field is required" />);
+      expect(screen.getByText('This field is required')).toBeInTheDocument();
+      expect(screen.queryByText('Normal hint')).not.toBeInTheDocument();
+    });
+
+    it('shows required indicator when required prop is set', () => {
+      render(<Textarea label="Name" required />);
+      expect(screen.getByText('*')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('sets aria-invalid when errorMessage is present', () => {
+      render(<Textarea errorMessage="Required" />);
+      expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('does not set aria-invalid without an error', () => {
+      render(<Textarea />);
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('links error message to textarea via aria-describedby', () => {
+      render(<Textarea id="test-ta" errorMessage="This is an error" />);
+      const textarea = screen.getByRole('textbox');
+      const errorId = textarea.getAttribute('aria-describedby');
+      expect(errorId).toBeTruthy();
+      const errorEl = document.getElementById(errorId!);
+      expect(errorEl).toHaveTextContent('This is an error');
+    });
+
+    it('links hint to textarea via aria-describedby', () => {
+      render(<Textarea id="test-ta" hint="Helpful hint" />);
+      const textarea = screen.getByRole('textbox');
+      const hintId = textarea.getAttribute('aria-describedby');
+      expect(hintId).toBeTruthy();
+      const hintEl = document.getElementById(hintId!);
+      expect(hintEl).toHaveTextContent('Helpful hint');
+    });
+  });
+
+  describe('interactions', () => {
+    it('accepts typed input', async () => {
+      const { user } = setup(<Textarea />);
+      const textarea = screen.getByRole('textbox');
+      await user.type(textarea, 'hello world');
+      expect(textarea).toHaveValue('hello world');
+    });
+
+    it('is disabled when disabled prop is true', () => {
+      render(<Textarea disabled />);
+      expect(screen.getByRole('textbox')).toBeDisabled();
+    });
+
+    it('is read-only when readOnly prop is true', () => {
+      render(<Textarea readOnly defaultValue="read only" />);
+      expect(screen.getByRole('textbox')).toHaveAttribute('readonly');
+    });
+
+    it('calls onInput handler when content changes', () => {
+      const onInput = vi.fn();
+      render(<Textarea onInput={onInput} />);
+      fireEvent.input(screen.getByRole('textbox'), { target: { value: 'new text' } });
+      expect(onInput).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('auto-resize', () => {
+    it('sets resize to none on the textarea when autoResize is enabled', () => {
+      render(<Textarea autoResize />);
+      const textarea = screen.getByRole('textbox');
+      const wrapper = textarea.parentElement!;
+      // The wrapper should have a class that sets resize: none
+      expect(wrapper.className).toMatch(/resize-none/);
+    });
+  });
+});

--- a/tests/Tooltip.test.tsx
+++ b/tests/Tooltip.test.tsx
@@ -118,7 +118,9 @@ describe('Tooltip', () => {
         </Tooltip>
       );
       const wrapper = container.firstChild as HTMLElement;
-      act(() => { fireEvent.mouseEnter(wrapper); });
+      act(() => {
+        fireEvent.mouseEnter(wrapper);
+      });
       expect(screen.getByRole('tooltip', { hidden: true })).toHaveAttribute('aria-hidden', 'true');
       vi.useRealTimers();
     });
@@ -131,8 +133,12 @@ describe('Tooltip', () => {
         </Tooltip>
       );
       const wrapper = container.firstChild as HTMLElement;
-      act(() => { fireEvent.mouseEnter(wrapper); });
-      act(() => { vi.advanceTimersByTime(300); });
+      act(() => {
+        fireEvent.mouseEnter(wrapper);
+      });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
       expect(screen.getByRole('tooltip', { hidden: true })).toHaveAttribute('aria-hidden', 'false');
       vi.useRealTimers();
     });

--- a/tests/Tooltip.test.tsx
+++ b/tests/Tooltip.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tooltip } from '../components/Tooltip/Tooltip';
+
+const setup = (jsx: React.ReactElement) => ({
+  user: userEvent.setup({ delay: null }),
+  ...render(jsx),
+});
+
+describe('Tooltip', () => {
+  describe('rendering', () => {
+    it('renders the trigger child', () => {
+      render(
+        <Tooltip content="Help text">
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      expect(screen.getByRole('button', { name: /trigger/i })).toBeInTheDocument();
+    });
+
+    it('renders tooltip with role="tooltip"', () => {
+      render(
+        <Tooltip content="Help text">
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument();
+    });
+
+    it('tooltip is hidden by default', () => {
+      render(
+        <Tooltip content="Help text">
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  describe('hover interactions', () => {
+    it('shows tooltip on mouse enter', async () => {
+      const { user } = setup(
+        <Tooltip content="Help text">
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole('button');
+      await user.hover(trigger);
+      expect(screen.getByRole('tooltip')).toHaveAttribute('aria-hidden', 'false');
+    });
+
+    it('hides tooltip on mouse leave', async () => {
+      const { user } = setup(
+        <Tooltip content="Help text">
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole('button');
+      await user.hover(trigger);
+      await user.unhover(trigger);
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  describe('keyboard interactions', () => {
+    it('shows tooltip on focus', async () => {
+      const { user } = setup(
+        <Tooltip content="Help text">
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      await user.tab();
+      expect(screen.getByRole('tooltip')).toHaveAttribute('aria-hidden', 'false');
+    });
+
+    it('hides tooltip on blur', async () => {
+      const { user } = setup(
+        <Tooltip content="Help text">
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      await user.tab();
+      await user.tab();
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('sets aria-describedby on trigger when visible', async () => {
+      const { user } = setup(
+        <Tooltip content="Help text">
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      await user.tab();
+      const trigger = screen.getByRole('button');
+      expect(trigger).toHaveAttribute('aria-describedby');
+      const id = trigger.getAttribute('aria-describedby')!;
+      expect(document.getElementById(id)).toHaveTextContent('Help text');
+    });
+
+    it('removes aria-describedby from trigger when hidden', () => {
+      render(
+        <Tooltip content="Help text">
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole('button');
+      expect(trigger).not.toHaveAttribute('aria-describedby');
+    });
+  });
+
+  describe('delay', () => {
+    it('does not show tooltip immediately when delay is set', () => {
+      vi.useFakeTimers();
+      const { container } = render(
+        <Tooltip content="Delayed" delay={300}>
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      const wrapper = container.firstChild as HTMLElement;
+      act(() => { fireEvent.mouseEnter(wrapper); });
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveAttribute('aria-hidden', 'true');
+      vi.useRealTimers();
+    });
+
+    it('shows tooltip after delay elapses', () => {
+      vi.useFakeTimers();
+      const { container } = render(
+        <Tooltip content="Delayed" delay={300}>
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      const wrapper = container.firstChild as HTMLElement;
+      act(() => { fireEvent.mouseEnter(wrapper); });
+      act(() => { vi.advanceTimersByTime(300); });
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveAttribute('aria-hidden', 'false');
+      vi.useRealTimers();
+    });
+  });
+});

--- a/tokens/primitive.tokens.json
+++ b/tokens/primitive.tokens.json
@@ -118,5 +118,37 @@
     "fast": { "$value": "100ms", "$type": "duration" },
     "normal": { "$value": "200ms", "$type": "duration" },
     "slow": { "$value": "300ms", "$type": "duration" }
+  },
+  "zIndex": {
+    "hide": { "$value": -1, "$type": "number" },
+    "base": { "$value": 0, "$type": "number" },
+    "raised": { "$value": 1, "$type": "number" },
+    "dropdown": { "$value": 100, "$type": "number" },
+    "sticky": { "$value": 200, "$type": "number" },
+    "overlay": { "$value": 300, "$type": "number" },
+    "modal": { "$value": 400, "$type": "number" },
+    "toast": { "$value": 500, "$type": "number" },
+    "tooltip": { "$value": 600, "$type": "number" }
+  },
+  "opacity": {
+    "disabled": { "$value": 0.4, "$type": "number" },
+    "muted": { "$value": 0.6, "$type": "number" },
+    "overlay": { "$value": 0.5, "$type": "number" }
+  },
+  "breakpoint": {
+    "sm": { "$value": "640px", "$type": "dimension" },
+    "md": { "$value": "768px", "$type": "dimension" },
+    "lg": { "$value": "1024px", "$type": "dimension" },
+    "xl": { "$value": "1280px", "$type": "dimension" },
+    "2xl": { "$value": "1536px", "$type": "dimension" }
+  },
+  "animation": {
+    "spin": { "$value": "1s", "$type": "duration" },
+    "pulse": { "$value": "2s", "$type": "duration" }
+  },
+  "easing": {
+    "easeIn": { "$value": "cubic-bezier(0.4, 0, 1, 1)" },
+    "easeOut": { "$value": "cubic-bezier(0, 0, 0.2, 1)" },
+    "easeInOut": { "$value": "cubic-bezier(0.4, 0, 0.2, 1)" }
   }
 }

--- a/tokens/semantic.light.tokens.json
+++ b/tokens/semantic.light.tokens.json
@@ -126,5 +126,37 @@
     "fast": { "$value": "100ms cubic-bezier(0, 0, 0.2, 1)", "$type": "duration" },
     "normal": { "$value": "200ms cubic-bezier(0.4, 0, 0.2, 1)", "$type": "duration" },
     "slow": { "$value": "300ms cubic-bezier(0.4, 0, 0.2, 1)", "$type": "duration" }
+  },
+  "zIndex": {
+    "hide": { "$value": "{zIndex.hide}", "$type": "number" },
+    "base": { "$value": "{zIndex.base}", "$type": "number" },
+    "raised": { "$value": "{zIndex.raised}", "$type": "number" },
+    "dropdown": { "$value": "{zIndex.dropdown}", "$type": "number" },
+    "sticky": { "$value": "{zIndex.sticky}", "$type": "number" },
+    "overlay": { "$value": "{zIndex.overlay}", "$type": "number" },
+    "modal": { "$value": "{zIndex.modal}", "$type": "number" },
+    "toast": { "$value": "{zIndex.toast}", "$type": "number" },
+    "tooltip": { "$value": "{zIndex.tooltip}", "$type": "number" }
+  },
+  "opacity": {
+    "disabled": { "$value": "{opacity.disabled}", "$type": "number" },
+    "muted": { "$value": "{opacity.muted}", "$type": "number" },
+    "overlay": { "$value": "{opacity.overlay}", "$type": "number" }
+  },
+  "breakpoint": {
+    "sm": { "$value": "{breakpoint.sm}", "$type": "dimension" },
+    "md": { "$value": "{breakpoint.md}", "$type": "dimension" },
+    "lg": { "$value": "{breakpoint.lg}", "$type": "dimension" },
+    "xl": { "$value": "{breakpoint.xl}", "$type": "dimension" },
+    "2xl": { "$value": "{breakpoint.2xl}", "$type": "dimension" }
+  },
+  "animation": {
+    "spin": { "$value": "{animation.spin}", "$type": "duration" },
+    "pulse": { "$value": "{animation.pulse}", "$type": "duration" }
+  },
+  "easing": {
+    "easeIn": { "$value": "{easing.easeIn}" },
+    "easeOut": { "$value": "{easing.easeOut}" },
+    "easeInOut": { "$value": "{easing.easeInOut}" }
   }
 }

--- a/tokens/types/tokens.types.ts
+++ b/tokens/types/tokens.types.ts
@@ -137,6 +137,30 @@ export type ElevationToken =
 
 export type TransitionToken = 'transition-fast' | 'transition-normal' | 'transition-slow';
 
+export type ZIndexToken =
+  | 'zIndex-hide'
+  | 'zIndex-base'
+  | 'zIndex-raised'
+  | 'zIndex-dropdown'
+  | 'zIndex-sticky'
+  | 'zIndex-overlay'
+  | 'zIndex-modal'
+  | 'zIndex-toast'
+  | 'zIndex-tooltip';
+
+export type OpacityToken = 'opacity-disabled' | 'opacity-muted' | 'opacity-overlay';
+
+export type BreakpointToken =
+  | 'breakpoint-sm'
+  | 'breakpoint-md'
+  | 'breakpoint-lg'
+  | 'breakpoint-xl'
+  | 'breakpoint-2xl';
+
+export type AnimationToken = 'animation-spin' | 'animation-pulse';
+
+export type EasingToken = 'easing-easeIn' | 'easing-easeOut' | 'easing-easeInOut';
+
 export type SemanticToken =
   | ColorBackgroundToken
   | ColorSurfaceToken
@@ -147,7 +171,12 @@ export type SemanticToken =
   | SpacingToken
   | BorderRadiusToken
   | ElevationToken
-  | TransitionToken;
+  | TransitionToken
+  | ZIndexToken
+  | OpacityToken
+  | BreakpointToken
+  | AnimationToken
+  | EasingToken;
 
 /** Build a typed CSS var() string from a semantic token */
 export type TokenVar<T extends SemanticToken> = `var(--ds-${T})`;


### PR DESCRIPTION
## Summary

- **#16 Token system expansion** — z-index (9 levels), opacity (disabled/muted/overlay), breakpoints as JS constants (`breakpoints` export from `token-vars.generated.ts`), animation durations (spin/pulse), easing functions. Transform script updated to emit `breakpoints` object. CLAUDE.md updated with breakpoint constraint.
- **#10 Textarea** — full Input API parity: `label`, `hint`, `errorMessage`, `status`, `size`, `resize` (none/vertical/both), `autoResize` (grows with content), `disabled`, `readOnly`. `aria-describedby` wired to hint/error.
- **#15 Tooltip** — wraps any single trigger element, all four placements, hover + keyboard focus/blur, configurable `delay`, `role="tooltip"`, `aria-describedby` on trigger, `--ds-zIndex-tooltip` token, `prefers-reduced-motion` respected.
- **#13 Tabs** — full ARIA tablist pattern (`role="tablist"`, `role="tab"`, `role="tabpanel"`, `aria-selected`, `aria-controls`, `aria-labelledby`), keyboard navigation (ArrowLeft/Right/Up/Down, Home, End with wrapping), controlled + uncontrolled, disabled tabs, vertical orientation, lazy panel rendering.

## Test plan

- [ ] `npm run typecheck` — passes clean
- [ ] `npm test` — 386 tests passing (47 new)
- [ ] `npm run tokens:validate` — all token files valid
- [ ] Storybook stories cover all variants and keyboard interaction tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)