### PR TITLE
feat: add Modal component

### DIFF
--- a/components/Modal/Modal.module.css
+++ b/components/Modal/Modal.module.css
@@ -1,0 +1,143 @@
+/* ── Overlay (backdrop) ── */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--ds-zIndex-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ds-spacing-layout-sm);
+  background-color: rgb(0 0 0 / var(--ds-opacity-overlay));
+  opacity: 0;
+  transition: opacity var(--ds-transition-normal);
+}
+
+.overlayVisible {
+  opacity: 1;
+}
+
+.overlayFullscreen {
+  padding: 0;
+}
+
+/* ── Dialog ── */
+
+.dialog {
+  position: relative;
+  z-index: var(--ds-zIndex-modal);
+  background-color: var(--ds-color-surface-default);
+  border: 1px solid var(--ds-color-border-default);
+  border-radius: var(--ds-borderRadius-card);
+  box-shadow: var(--ds-elevation-xl);
+  width: 100%;
+  max-height: calc(100vh - 2 * var(--ds-spacing-layout-sm));
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  opacity: 0;
+  transform: translateY(-8px) scale(0.97);
+  transition:
+    opacity var(--ds-transition-normal),
+    transform var(--ds-transition-normal);
+}
+
+.dialogVisible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+/* ── Size variants ── */
+
+.size-sm {
+  max-width: 400px;
+}
+
+.size-md {
+  max-width: 560px;
+}
+
+.size-lg {
+  max-width: 720px;
+}
+
+.size-fullscreen {
+  position: absolute;
+  inset: 0;
+  max-width: none;
+  max-height: none;
+  border-radius: 0;
+  border: none;
+}
+
+/* ── Header ── */
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ds-spacing-component-md);
+  padding: var(--ds-spacing-component-md) var(--ds-spacing-component-lg);
+  border-bottom: 1px solid var(--ds-color-border-default);
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-family: var(--ds-typography-fontFamily-body);
+  font-size: var(--ds-typography-fontSize-lg);
+  font-weight: var(--ds-typography-fontWeight-semibold);
+  color: var(--ds-color-text-default);
+  line-height: var(--ds-typography-lineHeight-tight);
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: var(--ds-borderRadius-button);
+  color: var(--ds-color-text-subtle);
+  cursor: pointer;
+  transition:
+    color var(--ds-transition-fast),
+    background-color var(--ds-transition-fast);
+}
+
+.closeButton:hover {
+  color: var(--ds-color-text-default);
+  background-color: var(--ds-color-background-muted);
+}
+
+.closeButton:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--ds-color-background-default),
+    0 0 0 4px var(--ds-color-border-focus);
+}
+
+/* ── Body ── */
+
+.body {
+  padding: var(--ds-spacing-component-lg);
+  flex: 1;
+  overflow-y: auto;
+  font-family: var(--ds-typography-fontFamily-body);
+  font-size: var(--ds-typography-fontSize-sm);
+  color: var(--ds-color-text-default);
+  line-height: var(--ds-typography-lineHeight-normal);
+}
+
+/* ── Reduced motion ── */
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay,
+  .dialog {
+    transition: none;
+  }
+}

--- a/components/Modal/Modal.module.css
+++ b/components/Modal/Modal.module.css
@@ -1,8 +1,12 @@
 /* ── Animations ── */
 
 @keyframes overlayIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes dialogIn {

--- a/components/Modal/Modal.module.css
+++ b/components/Modal/Modal.module.css
@@ -1,3 +1,21 @@
+/* ── Animations ── */
+
+@keyframes overlayIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes dialogIn {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 /* ── Overlay (backdrop) ── */
 
 .overlay {
@@ -9,12 +27,7 @@
   justify-content: center;
   padding: var(--ds-spacing-layout-sm);
   background-color: rgb(0 0 0 / var(--ds-opacity-overlay));
-  opacity: 0;
-  transition: opacity var(--ds-transition-normal);
-}
-
-.overlayVisible {
-  opacity: 1;
+  animation: overlayIn var(--ds-transition-normal) ease-out forwards;
 }
 
 .overlayFullscreen {
@@ -35,16 +48,7 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  opacity: 0;
-  transform: translateY(-8px) scale(0.97);
-  transition:
-    opacity var(--ds-transition-normal),
-    transform var(--ds-transition-normal);
-}
-
-.dialogVisible {
-  opacity: 1;
-  transform: translateY(0) scale(1);
+  animation: dialogIn var(--ds-transition-normal) ease-out forwards;
 }
 
 /* ── Size variants ── */
@@ -138,6 +142,6 @@
 @media (prefers-reduced-motion: reduce) {
   .overlay,
   .dialog {
-    transition: none;
+    animation: none;
   }
 }

--- a/components/Modal/Modal.stories.tsx
+++ b/components/Modal/Modal.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { userEvent, within, expect } from '@storybook/test';
+import { useState } from 'react';
+import { Modal } from './Modal';
+import { Button } from '../Button/Button';
+
+const meta = {
+  title: 'Components/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof Modal>;
+
+export default meta;
+
+function ModalDemo({
+  size = 'md',
+  closeOnBackdropClick = true,
+  closeOnEscape = true,
+}: {
+  size?: 'sm' | 'md' | 'lg' | 'fullscreen';
+  closeOnBackdropClick?: boolean;
+  closeOnEscape?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open {size} modal</Button>
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Example dialog"
+        size={size}
+        closeOnBackdropClick={closeOnBackdropClick}
+        closeOnEscape={closeOnEscape}
+      >
+        <p>
+          This is the modal body. It can contain any content — forms, confirmations, or rich media.
+        </p>
+        <div style={{ display: 'flex', gap: 8, marginTop: 16, justifyContent: 'flex-end' }}>
+          <Button variant="secondary" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => setOpen(false)}>Confirm</Button>
+        </div>
+      </Modal>
+    </>
+  );
+}
+
+export const Default: StoryFn<typeof Modal> = () => <ModalDemo />;
+
+export const Small: StoryFn<typeof Modal> = () => <ModalDemo size="sm" />;
+Small.storyName = 'Size: Small';
+
+export const Large: StoryFn<typeof Modal> = () => <ModalDemo size="lg" />;
+Large.storyName = 'Size: Large';
+
+export const Fullscreen: StoryFn<typeof Modal> = () => <ModalDemo size="fullscreen" />;
+Fullscreen.storyName = 'Size: Fullscreen';
+
+export const NoBackdropClose: StoryFn<typeof Modal> = () => (
+  <ModalDemo closeOnBackdropClick={false} />
+);
+NoBackdropClose.storyName = 'Backdrop click disabled';
+
+export const KeyboardInteraction: StoryFn<typeof Modal> = () => <ModalDemo />;
+KeyboardInteraction.storyName = 'Keyboard: Escape closes modal';
+KeyboardInteraction.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const trigger = canvas.getByRole('button', { name: /open md modal/i });
+
+  await userEvent.click(trigger);
+  const dialog = within(document.body).getByRole('dialog');
+  await expect(dialog).toBeInTheDocument();
+
+  await userEvent.keyboard('{Escape}');
+  await expect(within(document.body).queryByRole('dialog')).not.toBeInTheDocument();
+};

--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -1,0 +1,159 @@
+import { createPortal } from 'react-dom';
+import { useEffect, useId, useRef, type ReactNode } from 'react';
+import { cx } from '../../utils/token.utils';
+import styles from './Modal.module.css';
+
+export type ModalSize = 'sm' | 'md' | 'lg' | 'fullscreen';
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  size?: ModalSize;
+  closeOnBackdropClick?: boolean;
+  closeOnEscape?: boolean;
+  children: ReactNode;
+}
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS));
+}
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  size = 'md',
+  closeOnBackdropClick = true,
+  closeOnEscape = true,
+  children,
+}: ModalProps) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const returnFocusRef = useRef<Element | null>(null);
+
+  // Capture the element that triggered open — must run before the focus effect
+  useEffect(() => {
+    if (open) {
+      returnFocusRef.current = document.activeElement;
+    }
+  }, [open]);
+
+  // Move focus into dialog when it opens
+  useEffect(() => {
+    if (open && dialogRef.current) {
+      const focusable = getFocusable(dialogRef.current);
+      focusable[0]?.focus();
+    }
+  }, [open]);
+
+  // Return focus to trigger element on close
+  useEffect(() => {
+    if (!open && returnFocusRef.current instanceof HTMLElement) {
+      returnFocusRef.current.focus();
+    }
+  }, [open]);
+
+  // Body scroll lock
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // Document-level keyboard handler (Escape + focus trap)
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && closeOnEscape) {
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab' && dialogRef.current) {
+        const focusable = getFocusable(dialogRef.current);
+        if (focusable.length === 0) {
+          e.preventDefault();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, closeOnEscape, onClose]);
+
+  if (!open) return null;
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (closeOnBackdropClick && e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return createPortal(
+    // role="presentation" suppresses jsx-a11y interaction warnings on the backdrop div;
+    // keyboard handling is managed via the document-level listener above.
+    <div
+      role="presentation"
+      className={cx(styles.overlay, size === 'fullscreen' && styles.overlayFullscreen)}
+      onClick={handleBackdropClick}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className={cx(styles.dialog, styles[`size-${size}`])}
+      >
+        <div className={styles.header}>
+          <h2 id={titleId} className={styles.title}>
+            {title}
+          </h2>
+          <button
+            type="button"
+            aria-label="Close dialog"
+            className={styles.closeButton}
+            onClick={onClose}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="20"
+              height="20"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className={styles.body}>{children}</div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/components/index.ts
+++ b/components/index.ts
@@ -105,3 +105,7 @@ export type {
   TabPanelProps,
   TabsOrientation,
 } from './Tabs/Tabs';
+
+// Modal
+export { Modal } from './Modal/Modal';
+export type { ModalProps, ModalSize } from './Modal/Modal';

--- a/tests/Modal.test.tsx
+++ b/tests/Modal.test.tsx
@@ -9,12 +9,7 @@ function ControlledModal(props: Partial<React.ComponentProps<typeof Modal>>) {
   return (
     <>
       <button onClick={() => setOpen(true)}>Open</button>
-      <Modal
-        open={open}
-        onClose={() => setOpen(false)}
-        title="Test dialog"
-        {...props}
-      >
+      <Modal open={open} onClose={() => setOpen(false)} title="Test dialog" {...props}>
         <button>First</button>
         <button>Second</button>
         <button>Last</button>
@@ -31,28 +26,46 @@ const setup = (jsx: React.ReactElement) => ({
 describe('Modal', () => {
   describe('rendering', () => {
     it('does not render dialog when closed', () => {
-      render(<Modal open={false} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      render(
+        <Modal open={false} onClose={vi.fn()} title="Test">
+          <p>Body</p>
+        </Modal>
+      );
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
     it('renders dialog when open', () => {
-      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      render(
+        <Modal open={true} onClose={vi.fn()} title="Test">
+          <p>Body</p>
+        </Modal>
+      );
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     it('renders the title', () => {
-      render(<Modal open={true} onClose={vi.fn()} title="My Dialog"><p>Body</p></Modal>);
+      render(
+        <Modal open={true} onClose={vi.fn()} title="My Dialog">
+          <p>Body</p>
+        </Modal>
+      );
       expect(screen.getByText('My Dialog')).toBeInTheDocument();
     });
 
     it('renders children in the body', () => {
-      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Dialog content</p></Modal>);
+      render(
+        <Modal open={true} onClose={vi.fn()} title="Test">
+          <p>Dialog content</p>
+        </Modal>
+      );
       expect(screen.getByText('Dialog content')).toBeInTheDocument();
     });
 
     it('renders into document.body as a portal, not inside the render container', () => {
       const { container } = render(
-        <Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>
+        <Modal open={true} onClose={vi.fn()} title="Test">
+          <p>Body</p>
+        </Modal>
       );
       // The render container div should be empty — dialog is portalled to document.body
       expect(container.querySelector('[role="dialog"]')).toBeNull();
@@ -65,32 +78,51 @@ describe('Modal', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
 
       await user.click(screen.getByRole('button', { name: /close dialog/i }));
-      await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-      }, { timeout: 500 });
+      await waitFor(
+        () => {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        },
+        { timeout: 500 }
+      );
     });
   });
 
   describe('ARIA attributes', () => {
     it('has role="dialog"', () => {
-      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      render(
+        <Modal open={true} onClose={vi.fn()} title="Test">
+          <p>Body</p>
+        </Modal>
+      );
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     it('has aria-modal="true"', () => {
-      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      render(
+        <Modal open={true} onClose={vi.fn()} title="Test">
+          <p>Body</p>
+        </Modal>
+      );
       expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
     });
 
     it('has aria-labelledby pointing to the title', () => {
-      render(<Modal open={true} onClose={vi.fn()} title="My Dialog"><p>Body</p></Modal>);
+      render(
+        <Modal open={true} onClose={vi.fn()} title="My Dialog">
+          <p>Body</p>
+        </Modal>
+      );
       const dialog = screen.getByRole('dialog');
       const labelId = dialog.getAttribute('aria-labelledby')!;
       expect(document.getElementById(labelId)).toHaveTextContent('My Dialog');
     });
 
     it('has a close button with accessible label', () => {
-      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      render(
+        <Modal open={true} onClose={vi.fn()} title="Test">
+          <p>Body</p>
+        </Modal>
+      );
       expect(screen.getByRole('button', { name: /close dialog/i })).toBeInTheDocument();
     });
   });
@@ -99,7 +131,9 @@ describe('Modal', () => {
     it('calls onClose when close button is clicked', async () => {
       const onClose = vi.fn();
       const { user } = setup(
-        <Modal open={true} onClose={onClose} title="Test"><p>Body</p></Modal>
+        <Modal open={true} onClose={onClose} title="Test">
+          <p>Body</p>
+        </Modal>
       );
       await user.click(screen.getByRole('button', { name: /close dialog/i }));
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -108,7 +142,9 @@ describe('Modal', () => {
     it('calls onClose when Escape is pressed', async () => {
       const onClose = vi.fn();
       const { user } = setup(
-        <Modal open={true} onClose={onClose} title="Test"><p>Body</p></Modal>
+        <Modal open={true} onClose={onClose} title="Test">
+          <p>Body</p>
+        </Modal>
       );
       await user.keyboard('{Escape}');
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -127,7 +163,11 @@ describe('Modal', () => {
 
     it('calls onClose when backdrop is clicked', async () => {
       const onClose = vi.fn();
-      render(<Modal open={true} onClose={onClose} title="Test"><p>Body</p></Modal>);
+      render(
+        <Modal open={true} onClose={onClose} title="Test">
+          <p>Body</p>
+        </Modal>
+      );
       const overlay = document.body.querySelector('[class*="overlay"]') as HTMLElement;
       overlay.click();
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -161,9 +201,12 @@ describe('Modal', () => {
       const trigger = screen.getByRole('button', { name: /open/i });
       await user.click(trigger);
       await user.click(screen.getByRole('button', { name: /close dialog/i }));
-      await waitFor(() => {
-        expect(trigger).toHaveFocus();
-      }, { timeout: 500 });
+      await waitFor(
+        () => {
+          expect(trigger).toHaveFocus();
+        },
+        { timeout: 500 }
+      );
     });
 
     it('traps focus: Tab wraps from last to first element', async () => {
@@ -198,7 +241,11 @@ describe('Modal', () => {
 
   describe('scroll lock', () => {
     it('sets overflow:hidden on body when open', () => {
-      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      render(
+        <Modal open={true} onClose={vi.fn()} title="Test">
+          <p>Body</p>
+        </Modal>
+      );
       expect(document.body.style.overflow).toBe('hidden');
     });
 
@@ -207,9 +254,12 @@ describe('Modal', () => {
       await user.click(screen.getByRole('button', { name: /open/i }));
       expect(document.body.style.overflow).toBe('hidden');
       await user.click(screen.getByRole('button', { name: /close dialog/i }));
-      await waitFor(() => {
-        expect(document.body.style.overflow).not.toBe('hidden');
-      }, { timeout: 500 });
+      await waitFor(
+        () => {
+          expect(document.body.style.overflow).not.toBe('hidden');
+        },
+        { timeout: 500 }
+      );
     });
   });
 });

--- a/tests/Modal.test.tsx
+++ b/tests/Modal.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { Modal } from '../components/Modal/Modal';
+
+function ControlledModal(props: Partial<React.ComponentProps<typeof Modal>>) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open</button>
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Test dialog"
+        {...props}
+      >
+        <button>First</button>
+        <button>Second</button>
+        <button>Last</button>
+      </Modal>
+    </>
+  );
+}
+
+const setup = (jsx: React.ReactElement) => ({
+  user: userEvent.setup(),
+  ...render(jsx),
+});
+
+describe('Modal', () => {
+  describe('rendering', () => {
+    it('does not render dialog when closed', () => {
+      render(<Modal open={false} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders dialog when open', () => {
+      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('renders the title', () => {
+      render(<Modal open={true} onClose={vi.fn()} title="My Dialog"><p>Body</p></Modal>);
+      expect(screen.getByText('My Dialog')).toBeInTheDocument();
+    });
+
+    it('renders children in the body', () => {
+      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Dialog content</p></Modal>);
+      expect(screen.getByText('Dialog content')).toBeInTheDocument();
+    });
+
+    it('renders into document.body as a portal, not inside the render container', () => {
+      const { container } = render(
+        <Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>
+      );
+      // The render container div should be empty — dialog is portalled to document.body
+      expect(container.querySelector('[role="dialog"]')).toBeNull();
+      expect(document.body.querySelector('[role="dialog"]')).toBeInTheDocument();
+    });
+
+    it('unmounts from DOM when closed after being open', async () => {
+      const { user } = setup(<ControlledModal />);
+      await user.click(screen.getByRole('button', { name: /open/i }));
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /close dialog/i }));
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      }, { timeout: 500 });
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('has role="dialog"', () => {
+      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('has aria-modal="true"', () => {
+      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('has aria-labelledby pointing to the title', () => {
+      render(<Modal open={true} onClose={vi.fn()} title="My Dialog"><p>Body</p></Modal>);
+      const dialog = screen.getByRole('dialog');
+      const labelId = dialog.getAttribute('aria-labelledby')!;
+      expect(document.getElementById(labelId)).toHaveTextContent('My Dialog');
+    });
+
+    it('has a close button with accessible label', () => {
+      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      expect(screen.getByRole('button', { name: /close dialog/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('close behaviour', () => {
+    it('calls onClose when close button is clicked', async () => {
+      const onClose = vi.fn();
+      const { user } = setup(
+        <Modal open={true} onClose={onClose} title="Test"><p>Body</p></Modal>
+      );
+      await user.click(screen.getByRole('button', { name: /close dialog/i }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when Escape is pressed', async () => {
+      const onClose = vi.fn();
+      const { user } = setup(
+        <Modal open={true} onClose={onClose} title="Test"><p>Body</p></Modal>
+      );
+      await user.keyboard('{Escape}');
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose on Escape when closeOnEscape=false', async () => {
+      const onClose = vi.fn();
+      const { user } = setup(
+        <Modal open={true} onClose={onClose} title="Test" closeOnEscape={false}>
+          <p>Body</p>
+        </Modal>
+      );
+      await user.keyboard('{Escape}');
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when backdrop is clicked', async () => {
+      const onClose = vi.fn();
+      render(<Modal open={true} onClose={onClose} title="Test"><p>Body</p></Modal>);
+      const overlay = document.body.querySelector('[class*="overlay"]') as HTMLElement;
+      overlay.click();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose on backdrop click when closeOnBackdropClick=false', async () => {
+      const onClose = vi.fn();
+      render(
+        <Modal open={true} onClose={onClose} title="Test" closeOnBackdropClick={false}>
+          <p>Body</p>
+        </Modal>
+      );
+      const overlay = document.body.querySelector('[class*="overlay"]') as HTMLElement;
+      overlay.click();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('focus management', () => {
+    it('focuses the first focusable element on open', async () => {
+      const { user } = setup(<ControlledModal />);
+      await user.click(screen.getByRole('button', { name: /open/i }));
+      // First focusable element inside the dialog is the close button
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /close dialog/i })).toHaveFocus();
+      });
+    });
+
+    it('returns focus to trigger element on close', async () => {
+      const { user } = setup(<ControlledModal />);
+      const trigger = screen.getByRole('button', { name: /open/i });
+      await user.click(trigger);
+      await user.click(screen.getByRole('button', { name: /close dialog/i }));
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
+      }, { timeout: 500 });
+    });
+
+    it('traps focus: Tab wraps from last to first element', async () => {
+      const { user } = setup(<ControlledModal />);
+      await user.click(screen.getByRole('button', { name: /open/i }));
+
+      // Tab through all focusable elements to reach the last one
+      const closeBtn = screen.getByRole('button', { name: /close dialog/i });
+      await waitFor(() => expect(closeBtn).toHaveFocus());
+
+      // Tab past First, Second, Last buttons
+      await user.tab(); // → First
+      await user.tab(); // → Second
+      await user.tab(); // → Last
+      // Tab again should wrap back to close button (first focusable)
+      await user.tab();
+      expect(closeBtn).toHaveFocus();
+    });
+
+    it('traps focus: Shift+Tab wraps from first to last element', async () => {
+      const { user } = setup(<ControlledModal />);
+      await user.click(screen.getByRole('button', { name: /open/i }));
+
+      const closeBtn = screen.getByRole('button', { name: /close dialog/i });
+      await waitFor(() => expect(closeBtn).toHaveFocus());
+
+      // Shift+Tab from first element should wrap to last
+      await user.tab({ shift: true });
+      expect(screen.getByRole('button', { name: /last/i })).toHaveFocus();
+    });
+  });
+
+  describe('scroll lock', () => {
+    it('sets overflow:hidden on body when open', () => {
+      render(<Modal open={true} onClose={vi.fn()} title="Test"><p>Body</p></Modal>);
+      expect(document.body.style.overflow).toBe('hidden');
+    });
+
+    it('restores body overflow when closed', async () => {
+      const { user } = setup(<ControlledModal />);
+      await user.click(screen.getByRole('button', { name: /open/i }));
+      expect(document.body.style.overflow).toBe('hidden');
+      await user.click(screen.getByRole('button', { name: /close dialog/i }));
+      await waitFor(() => {
+        expect(document.body.style.overflow).not.toBe('hidden');
+      }, { timeout: 500 });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Accessible `<Modal>` component with `createPortal` to `document.body`
- Focus trap (Tab/Shift+Tab cycles through focusable elements via document-level listener)
- Scroll lock (`overflow: hidden` on body, restored on close)
- Close via: close button, Escape key, backdrop click — each individually toggleable
- Four size variants: `sm` (400px), `md` (560px), `lg` (720px), `fullscreen`
- CSS `@keyframes` enter animation (no JS state, avoids `setState-in-effect` lint rule)
- `role="presentation"` on backdrop to satisfy `jsx-a11y` interaction rules
- Closes #11

## Test plan

- [x] 21 tests: rendering, ARIA attributes, close behaviour, focus management, scroll lock
- [x] TypeScript strict — no `any`, no type errors
- [x] ESLint clean (including `react-hooks/set-state-in-effect` and `jsx-a11y` rules)
- [x] Production build passes
- [x] 407/407 tests across full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)