### PR TITLE
fix: remove 100vh min-height from Storybook story wrapper

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -19,7 +19,7 @@ const withTheme: Decorator = (Story, context) => {
       <div
         style={{
           padding: '2rem',
-          minHeight: '100vh',
+          minHeight: 'unset',
           background: 'var(--ds-color-background-default)',
           color: 'var(--ds-color-text-default)',
           fontFamily: 'var(--ds-typography-fontFamily-body)',


### PR DESCRIPTION
## Summary
- Story panels in Storybook were forced to full viewport height (`minHeight: '100vh'`) regardless of content size
- Changed to `minHeight: 'unset'` so panels size naturally to their content

## Test plan
- [ ] Open Storybook and verify story panels no longer have excessive height
- [ ] Confirm components still render correctly with padding and theming intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)